### PR TITLE
fix: prevent cmd_profile from duplicating output to stdout

### DIFF
--- a/survey-automation-roadmap/src/survey_automation/cli.py
+++ b/survey-automation-roadmap/src/survey_automation/cli.py
@@ -70,7 +70,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     profile_parser = subparsers.add_parser("profile", help="Profile input files and detected types")
     profile_parser.add_argument("--input-dir", required=True, help="Directory with input files")
-    profile_parser.add_argument("--output", required=True, help="JSON output path")
+    profile_parser.add_argument("--output", required=False, help="JSON output path")
     profile_parser.add_argument(
         "--config",
         required=False,
@@ -174,11 +174,14 @@ def cmd_profile(args: argparse.Namespace) -> int:
             return 3
 
     input_dir = Path(args.input_dir).resolve()
-    output_path = Path(args.output).resolve()
     profile = profile_input(input_dir=input_dir, config=config)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(profile, indent=2, sort_keys=True), encoding="utf-8")
-    if not args.quiet:
+
+    if args.output:
+        output_path = Path(args.output).resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(profile, indent=2, sort_keys=True), encoding="utf-8")
+
+    if not args.quiet and not args.output:
         _print_json(profile)
     return 0
 

--- a/survey-automation-roadmap/tests/unit/test_cli_profile.py
+++ b/survey-automation-roadmap/tests/unit/test_cli_profile.py
@@ -85,3 +85,41 @@ def test_profile_command_quiet_suppresses_stdout(tmp_path, capsys) -> None:
     assert exit_code == 0
     assert output.exists()
     assert capsys.readouterr().out.strip() == ""
+
+
+def test_profile_command_without_output_prints_to_stdout(tmp_path, capsys) -> None:
+    input_dir = tmp_path / "input"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    (input_dir / "a.csv").write_text("Field Code,Layer,Symbol,Linework\nCP,PNTS,DOT1,YES\n", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "profile",
+            "--input-dir",
+            str(input_dir),
+        ]
+    )
+    assert exit_code == 0
+    stdout = capsys.readouterr().out.strip()
+    payload = json.loads(stdout)
+    assert payload["files_total"] == 1
+
+
+def test_profile_command_with_output_suppresses_stdout_by_default(tmp_path, capsys) -> None:
+    input_dir = tmp_path / "input"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    (input_dir / "a.csv").write_text("Field Code,Layer,Symbol,Linework\nCP,PNTS,DOT1,YES\n", encoding="utf-8")
+    output = tmp_path / "profile.json"
+
+    exit_code = main(
+        [
+            "profile",
+            "--input-dir",
+            str(input_dir),
+            "--output",
+            str(output),
+        ]
+    )
+    assert exit_code == 0
+    assert output.exists()
+    assert capsys.readouterr().out.strip() == ""


### PR DESCRIPTION
The `profile` command in `survey-automation-roadmap/src/survey_automation/cli.py` previously duplicated its JSON output to both a file (if `--output` was provided) and `stdout`. This caused issues for scripts redirecting `stdout` to the same output file. 

This change:
1.  Makes `--output` optional in the `argparse` configuration for the `profile` command.
2.  Updates `cmd_profile` to only print to `stdout` if `--output` is missing and `--quiet` is not set.
3.  Adds and updates unit tests in `tests/unit/test_cli_profile.py` to cover these scenarios.
4.  Ensures that when `--output` is used, nothing is printed to `stdout` by default, fixing the reported bug.

---
*PR created automatically by Jules for task [1650957920858087937](https://jules.google.com/task/1650957920858087937) started by @sburdges-eng*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, well-tested change limited to CLI argument handling and output routing; main impact is a minor behavior change for scripts relying on stdout when `--output` is provided.
> 
> **Overview**
> **`profile` CLI output behavior is corrected to avoid duplication.** The `--output` flag is now optional, and `cmd_profile` only prints JSON to stdout when *no* `--output` is provided (and `--quiet` is not set); when `--output` is set, output goes to the file only.
> 
> Unit tests are updated/added to cover the new stdout/file behavior, including printing to stdout when `--output` is omitted and suppressing stdout by default when `--output` is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebc52ac345ca30bdf0418af85018f846a4f2dcab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->