### PR TITLE
Agentic continuation: L-5 deferred flow + A-8 single-write-API guard + ruff sweep

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -122,6 +122,7 @@ audit:
     - "lint_complete"
     - "accept"
     - "reject"
+    - "defer"  # L-5: surveyor deferred review to next session
     - "promote"
     - "promote_blocked"
     - "certify"

--- a/tests/test_audit_single_write_api.py
+++ b/tests/test_audit_single_write_api.py
@@ -1,0 +1,86 @@
+"""A-8: AuditLogger exposes exactly one write surface (`log`).
+
+Defensive guard against drift. Future refactors that add an alternative
+write path (e.g. `log_raw`, `append_record`, `bulk_log`) trip this test
+and force an explicit decision: either re-bless the new surface (update
+this test) or remove it (preserve the single-writer invariant).
+
+The single-writer invariant matters because every write must traverse the
+hash-chain logic in `log()`. A bypass surface — even one that looks
+innocuous — could allow records to land without `prev_hash` linkage.
+"""
+
+import inspect
+
+from totali.audit.logger import AuditLogger
+
+
+# Methods that legitimately appear on AuditLogger but are NOT write paths.
+_NON_WRITE_METHODS = frozenset({
+    "__init__",
+    "verify_chain",
+    "get_events",
+    "summary",
+    "close",  # close() calls log() internally; not an alt write path
+})
+
+# The ONE blessed write API.
+_WRITE_METHODS = frozenset({"log"})
+
+
+def _public_methods(cls):
+    return frozenset(
+        name for name, attr in inspect.getmembers(cls, inspect.isfunction)
+        if not name.startswith("_")
+    )
+
+
+class TestSingleWriteSurface:
+    def test_log_is_the_only_writer(self):
+        """Any new public method must be classified — either bless it as a
+        write surface (update _WRITE_METHODS) or as non-write (update
+        _NON_WRITE_METHODS). Drift fails loudly."""
+        public = _public_methods(AuditLogger)
+        unclassified = public - _WRITE_METHODS - _NON_WRITE_METHODS
+        assert not unclassified, (
+            f"AuditLogger has unclassified public methods: {sorted(unclassified)}. "
+            "Bless each as a write surface or non-write in this test, then "
+            "verify the single-writer invariant still holds."
+        )
+
+    def test_write_methods_set_is_singleton(self):
+        assert _WRITE_METHODS == {"log"}, (
+            "TOTaLi A-8 invariant: AuditLogger.log is the only blessed write "
+            "surface. Adding another writer requires explicit re-blessing here "
+            "AND a design review of the hash-chain bypass risk."
+        )
+
+    def test_log_signature_unchanged(self):
+        """Argument names + count are part of the contract; downstream callers
+        and the agent orchestration spec depend on them."""
+        sig = inspect.signature(AuditLogger.log)
+        params = list(sig.parameters.keys())
+        # self + event_type + data
+        assert params == ["self", "event_type", "data"], params
+
+
+class TestNoBypassPaths:
+    def test_no_open_method(self):
+        """No public method named anything like open/append/write/bulk."""
+        public = _public_methods(AuditLogger)
+        suspicious_substrings = ("write", "append", "bulk", "raw", "direct")
+        suspicious = {
+            m for m in public
+            if any(s in m.lower() for s in suspicious_substrings)
+        }
+        assert not suspicious, (
+            f"AuditLogger has suspicious-looking public methods: {sorted(suspicious)}. "
+            "If they are legitimate, add to _NON_WRITE_METHODS in this test."
+        )
+
+    def test_log_path_attribute_is_path_only(self):
+        """log_path exposed for inspection (verify_chain, tests) but is not "
+        a write surface."""
+        from pathlib import Path
+        logger = AuditLogger(log_dir="/tmp/totali_test_a8", project_id="a8")
+        assert isinstance(logger.log_path, Path)

--- a/tests/test_linting_deferred.py
+++ b/tests/test_linting_deferred.py
@@ -1,0 +1,103 @@
+"""L-5: deferred-feature flow.
+
+Surveyor can defer review to next session. Deferred items:
+- transition to GeometryStatus.DEFERRED
+- stay on the -DRAFT layer (no silent promotion)
+- emit a `defer` audit event with reviewer + reason
+- block `promote_to_certified` (uncertain ≠ decided)
+"""
+
+from totali.audit.logger import AuditLogger
+from totali.linting.surveyor_lint import SurveyorLinter
+from totali.pipeline.models import GeometryStatus, LintItem
+
+
+def _audit(tmp_path):
+    return AuditLogger(log_dir=str(tmp_path / "audit"), project_id="lint-defer")
+
+
+class TestDeferItem:
+    def test_status_transitions_to_deferred(self, tmp_path):
+        audit = _audit(tmp_path)
+        item = LintItem(
+            item_id="x", geometry_type="LINE",
+            layer="TOTaLi-SURV-BRKLN-DRAFT",
+        )
+        SurveyorLinter.defer_item(item, "PLS Sean", audit, "needs field check")
+        assert item.status == GeometryStatus.DEFERRED
+        assert item.reviewer == "PLS Sean"
+        assert item.notes == "needs field check"
+        assert item.review_timestamp is not None
+
+    def test_layer_unchanged_on_defer(self, tmp_path):
+        audit = _audit(tmp_path)
+        item = LintItem(
+            item_id="x", geometry_type="LINE",
+            layer="TOTaLi-PLAN-BLDG-DRAFT",
+        )
+        SurveyorLinter.defer_item(item, "PLS", audit)
+        assert item.layer == "TOTaLi-PLAN-BLDG-DRAFT", (
+            "deferred items must remain on -DRAFT layer; no silent promotion"
+        )
+
+    def test_emits_defer_audit_event(self, tmp_path):
+        audit = _audit(tmp_path)
+        item = LintItem(
+            item_id="abc", geometry_type="POLYGON",
+            layer="TOTaLi-PLAN-BLDG-DRAFT",
+        )
+        SurveyorLinter.defer_item(item, "PLS Jane", audit, "boundary unclear")
+        events = audit.get_events("defer")
+        assert len(events) == 1
+        payload = events[0]["data"]
+        assert payload["item_id"] == "abc"
+        assert payload["reviewer"] == "PLS Jane"
+        assert payload["reason"] == "boundary unclear"
+        assert payload["remains_on_layer"] == "TOTaLi-PLAN-BLDG-DRAFT"
+
+
+class TestPromoteBlocksOnDeferred:
+    def test_deferred_items_block_promotion(self, tmp_path):
+        audit = _audit(tmp_path)
+        items = [
+            LintItem(item_id="a", geometry_type="LINE", layer="L-DRAFT",
+                     status=GeometryStatus.ACCEPTED),
+            LintItem(item_id="b", geometry_type="LINE", layer="L-DRAFT",
+                     status=GeometryStatus.DEFERRED),
+        ]
+        result = SurveyorLinter.promote_to_certified(items, "PLS", "12345", audit)
+        assert result is False, "DEFERRED items must block promotion"
+        # Accepted item must NOT be silently promoted to CERTIFIED.
+        assert items[0].status == GeometryStatus.ACCEPTED
+
+    def test_promote_blocked_audit_mentions_deferred(self, tmp_path):
+        audit = _audit(tmp_path)
+        items = [
+            LintItem(item_id="a", geometry_type="LINE", layer="L-DRAFT",
+                     status=GeometryStatus.DEFERRED),
+        ]
+        SurveyorLinter.promote_to_certified(items, "PLS", "12345", audit)
+        events = audit.get_events("promote_blocked")
+        assert events
+        assert "DEFERRED" in events[0]["data"]["reason"]
+
+    def test_all_accepted_or_rejected_promotes_normally(self, tmp_path):
+        audit = _audit(tmp_path)
+        items = [
+            LintItem(item_id="a", geometry_type="LINE", layer="L-DRAFT",
+                     status=GeometryStatus.ACCEPTED),
+            LintItem(item_id="b", geometry_type="LINE", layer="L-DRAFT",
+                     status=GeometryStatus.REJECTED),
+        ]
+        result = SurveyorLinter.promote_to_certified(items, "PLS", "12345", audit)
+        assert result is True
+        assert items[0].status == GeometryStatus.CERTIFIED
+
+
+class TestDeferredEnumValue:
+    def test_deferred_in_geometry_status(self):
+        assert GeometryStatus.DEFERRED.value == "DEFERRED"
+        # Distinct from every other state.
+        all_statuses = {s.value for s in GeometryStatus}
+        assert "DEFERRED" in all_statuses
+        assert len(all_statuses) >= 6

--- a/totali/extraction/extractor.py
+++ b/totali/extraction/extractor.py
@@ -8,11 +8,9 @@ Produces measurable error metrics and QA flags.
 
 import json
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 from scipy.spatial import Delaunay
-from scipy.ndimage import uniform_filter1d
 
 from totali.pipeline.models import (
     PhaseResult, ExtractionResult, ClassificationResult

--- a/totali/linting/surveyor_lint.py
+++ b/totali/linting/surveyor_lint.py
@@ -280,18 +280,42 @@ class SurveyorLinter(PipelinePhase):
         })
 
     @staticmethod
+    def defer_item(item: LintItem, reviewer: str, audit: AuditLogger, notes: str = ""):
+        """L-5: defer review to a later session. Item stays on the -DRAFT layer
+        and surfaces again next session. Distinct from accept/reject — operator
+        wants more info or is uncertain. Never silently drops.
+        """
+        item.status = GeometryStatus.DEFERRED
+        item.reviewer = reviewer
+        item.review_timestamp = datetime.now(timezone.utc).isoformat()
+        item.notes = notes
+        audit.log("defer", {
+            "item_id": item.item_id,
+            "reviewer": reviewer,
+            "reason": notes,
+            "timestamp": item.review_timestamp,
+            "remains_on_layer": item.layer,
+        })
+
+    @staticmethod
     def promote_to_certified(
         items: list, pls_name: str, pls_license: str, audit: AuditLogger
     ) -> bool:
         """
         Promote all accepted items to certified status.
-        Requires ALL items to be either ACCEPTED or REJECTED (no DRAFT remaining).
-        Returns False if any items are still in DRAFT status.
+        Requires ALL items to be ACCEPTED or REJECTED. DRAFT and DEFERRED both
+        block promotion (DEFERRED = surveyor explicitly punted to next session;
+        not a decision until they revisit).
+        Returns False if any items are still in DRAFT or DEFERRED status.
         """
         draft_remaining = [i for i in items if i.status == GeometryStatus.DRAFT]
-        if draft_remaining:
+        deferred_remaining = [i for i in items if i.status == GeometryStatus.DEFERRED]
+        if draft_remaining or deferred_remaining:
             audit.log("promote_blocked", {
-                "reason": f"{len(draft_remaining)} items still in DRAFT status",
+                "reason": (
+                    f"{len(draft_remaining)} items still in DRAFT, "
+                    f"{len(deferred_remaining)} items DEFERRED"
+                ),
                 "pls": pls_name,
             })
             return False

--- a/totali/pipeline/models.py
+++ b/totali/pipeline/models.py
@@ -15,6 +15,7 @@ class GeometryStatus(str, Enum):
     FLAGGED = "FLAGGED"
     ACCEPTED = "ACCEPTED"
     REJECTED = "REJECTED"
+    DEFERRED = "DEFERRED"  # L-5: surveyor deferred review to next session
     CERTIFIED = "CERTIFIED"
 
 

--- a/totali/segmentation/classifier.py
+++ b/totali/segmentation/classifier.py
@@ -5,9 +5,7 @@ Non-authoritative classification. Produces probabilities + confidence, NOT geome
 Uses ONNX runtime for model inference on point cloud batches.
 """
 
-import time
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 


### PR DESCRIPTION
## Summary

Next autonomous-completion turn on top of the freshly-merged `main` (#95).

3 commits, 494 → 506 passed / 0 failed, ruff clean.

## Commits

- `3934475c` **feat(linting): L-5 deferred-feature flow**
- `9df1bae3` **test(audit): A-8 single-write-API guard**
- `f4ba9e66` **chore(ruff): sweep 4 unused-import warnings**

## L-5: three-decision review flow

Surveyor can now DEFER review to a later session. Deferred items:
- transition to `GeometryStatus.DEFERRED` (new enum value, additive)
- stay on the `-DRAFT` layer (no silent promotion)
- emit `defer` audit event with reviewer + reason + remains_on_layer
- **block** `promote_to_certified` (uncertain ≠ decided)

Files: `totali/pipeline/models.py` (enum), `totali/linting/surveyor_lint.py` (`defer_item` static method + promotion-block on DEFERRED), `config/pipeline.yaml` (allowlist `defer`), `tests/test_linting_deferred.py` (7 new tests).

The drift-net test (`test_audit_events_exhaustive`) caught the new emit and required the allowlist update — working as designed.

## A-8: single-write-API guard

Pins `AuditLogger`'s public surface: `log` is the one blessed write path; everything else is classified as non-write (`__init__`, `verify_chain`, `get_events`, `summary`, `close`).

Rationale: every write must traverse the hash-chain logic in `log()`. A future refactor that adds `log_raw`, `append_record`, `bulk_log`, etc. could let records land without `prev_hash` linkage. This test fails loudly on any unclassified method so the choice becomes explicit.

Also guards:
- `log()` signature `(self, event_type, data)` unchanged
- no suspicious-named public methods (write/append/bulk/raw/direct)

Files: `tests/test_audit_single_write_api.py` (5 new tests).

## Ruff sweep

4 carryover unused-import warnings in production code the earlier cleanup only reached in test files:
- `totali/extraction/extractor.py`: `typing.Optional`, `scipy.ndimage.uniform_filter1d`
- `totali/segmentation/classifier.py`: `time`, `typing.Optional`

No behavior change.

## Test plan

- [x] `pytest -q` — 506 passed / 0 failed / 0 skipped
- [x] `ruff check totali/ tests/` — clean
- [x] `python -c "import yaml; yaml.safe_load(open('config/pipeline.yaml'))"` — OK
- [x] Drift-net `test_audit_events_exhaustive` passes (new `defer` event allowlisted)
- [x] No conflicts with `origin/main` (fresh branch from current `main`)

## Scope discipline

Stayed within TOTaLi's defensibility-pipeline slice per `Docs/TOTALI_MAPPING_TO_PRODUCTION_DESIGN.md`. No kernel / JEPA / vector-memory work introduced — those remain auracad/L4L/orchestrator-tier concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new `GeometryStatus` and changes promotion-blocking logic in the certification path, which could affect downstream workflows if any code assumes only DRAFT/ACCEPTED/REJECTED.
> 
> **Overview**
> Adds an L-5 *deferred review* path: `SurveyorLinter.defer_item()` sets items to `GeometryStatus.DEFERRED`, records reviewer/notes/timestamp, and emits a new `defer` audit event (now allowlisted in `config/pipeline.yaml`).
> 
> Updates `promote_to_certified()` so **both** `DRAFT` and `DEFERRED` items block promotion and the `promote_blocked` reason includes deferred counts; adds tests covering the new status/emit/promotion-block behavior.
> 
> Adds an A-8 regression test that enforces `AuditLogger` has a single public write surface (`log`) with a stable signature, and removes a few unused imports in extractor/classifier modules (ruff cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ba9e66953be4be9443bb9d9f6ae73967eef3eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->