### PR TITLE
feat(external): contract surfaces for auracad + L4L integration (+58 tests)

### DIFF
--- a/tests/test_external_contracts.py
+++ b/tests/test_external_contracts.py
@@ -1,0 +1,259 @@
+"""Contract-shape tests for totali.external.
+
+Verifies:
+- All sibling-service output carries the non-authoritative invariant (L4L).
+- Schema versions are frozen semver strings.
+- Enum-like fields (format, embedding space, layer suffix) reject unknowns.
+- Numeric fields respect their bounds.
+- Protocol definitions exist and have the expected public methods.
+"""
+
+import inspect
+
+import pytest
+from pydantic import ValidationError
+
+from totali.external import (
+    AuracadAdapter,
+    AuracadHealReport,
+    AuracadReadReport,
+    AuracadTransformReport,
+    L4LAnomalyScore,
+    L4LInferenceAdapter,
+    L4LProposal,
+    L4LSceneEmbedding,
+)
+from totali.external.auracad_contract import AURACAD_CONTRACT_VERSION
+from totali.external.l4l_contract import L4L_CONTRACT_VERSION
+
+
+# ------------------------------------------------------------------------
+# Version pins
+# ------------------------------------------------------------------------
+
+class TestContractVersions:
+    def test_auracad_contract_version_is_semver(self):
+        assert AURACAD_CONTRACT_VERSION == "1.0.0"
+
+    def test_l4l_contract_version_is_semver(self):
+        assert L4L_CONTRACT_VERSION == "1.0.0"
+
+
+# ------------------------------------------------------------------------
+# Auracad contracts
+# ------------------------------------------------------------------------
+
+class TestAuracadReadReport:
+    def test_minimum_fields_accepted(self):
+        r = AuracadReadReport(file="x.dxf", format="dxf")
+        assert r.schema_version == "1.0.0"
+        assert r.layers == []
+        assert r.errors == []
+
+    @pytest.mark.parametrize("fmt", ["dxf", "dwg"])
+    def test_known_formats(self, fmt):
+        r = AuracadReadReport(file="x", format=fmt)
+        assert r.format == fmt
+
+    @pytest.mark.parametrize("bad", ["svg", "pdf", "DXF", ""])
+    def test_unknown_formats_rejected(self, bad):
+        with pytest.raises(ValidationError):
+            AuracadReadReport(file="x", format=bad)
+
+    def test_extra_fields_forbidden(self):
+        with pytest.raises(ValidationError):
+            AuracadReadReport(file="x", format="dxf", extra_key="nope")
+
+
+class TestAuracadHealReport:
+    def test_non_negative_counts(self):
+        r = AuracadHealReport(
+            input_entity_count=10, healed_count=2,
+            quarantined_count=1, passed_count=7,
+        )
+        assert r.healed_count == 2
+
+    @pytest.mark.parametrize("field", ["input_entity_count", "healed_count",
+                                        "quarantined_count", "passed_count"])
+    def test_negative_count_rejected(self, field):
+        payload = {
+            "input_entity_count": 0, "healed_count": 0,
+            "quarantined_count": 0, "passed_count": 0,
+        }
+        payload[field] = -1
+        with pytest.raises(ValidationError):
+            AuracadHealReport(**payload)
+
+
+class TestAuracadTransformReport:
+    def test_basic(self):
+        r = AuracadTransformReport(
+            source_epsg=2231, target_epsg=4326,
+            proj_version="9.4.1", point_count=500,
+        )
+        assert r.proj_version == "9.4.1"
+        assert r.point_count == 500
+
+
+# ------------------------------------------------------------------------
+# L4L non-authoritative invariant (the critical one)
+# ------------------------------------------------------------------------
+
+class TestL4LAuthoritativeInvariant:
+    """S-7 mirror: every L4L output must refuse authoritative=True at construction."""
+
+    def test_scene_embedding_default_false(self):
+        e = L4LSceneEmbedding(
+            space="scene_global", vector_len=512,
+            model_id="jepa-v1", model_sha256="a" * 64,
+        )
+        assert e.authoritative is False
+
+    def test_anomaly_score_default_false(self):
+        a = L4LAnomalyScore(
+            target_id="obj-1", score=0.7,
+            model_id="jepa-v1", model_sha256="a" * 64,
+        )
+        assert a.authoritative is False
+
+    def test_proposal_default_false(self):
+        p = L4LProposal(
+            proposal_kind="action_hint", rationale="test", confidence=0.5,
+        )
+        assert p.authoritative is False
+
+    @pytest.mark.parametrize(
+        "cls,kwargs",
+        [
+            (L4LSceneEmbedding, dict(space="scene_global", vector_len=1,
+                                      model_id="m", model_sha256="a" * 64)),
+            (L4LAnomalyScore, dict(target_id="t", score=0.5,
+                                    model_id="m", model_sha256="a" * 64)),
+            (L4LProposal, dict(proposal_kind="action_hint",
+                                rationale="r", confidence=0.5)),
+        ],
+    )
+    @pytest.mark.parametrize("truthy", [True, 1, "yes"])
+    def test_truthy_authoritative_rejected(self, cls, kwargs, truthy):
+        with pytest.raises(ValidationError):
+            cls(**kwargs, authoritative=truthy)
+
+
+class TestL4LSceneEmbedding:
+    @pytest.mark.parametrize("space", [
+        "scene_global", "tile_visual", "object_semantic",
+        "object_geometry", "command_context", "code_module",
+    ])
+    def test_known_spaces(self, space):
+        e = L4LSceneEmbedding(
+            space=space, vector_len=128,
+            model_id="m", model_sha256="a" * 64,
+        )
+        assert e.space == space
+
+    def test_unknown_space_rejected(self):
+        with pytest.raises(ValidationError):
+            L4LSceneEmbedding(
+                space="made_up", vector_len=128,
+                model_id="m", model_sha256="a" * 64,
+            )
+
+    def test_sha256_length_enforced(self):
+        with pytest.raises(ValidationError):
+            L4LSceneEmbedding(
+                space="scene_global", vector_len=128,
+                model_id="m", model_sha256="tooshort",
+            )
+
+    def test_vector_len_positive(self):
+        with pytest.raises(ValidationError):
+            L4LSceneEmbedding(
+                space="scene_global", vector_len=0,
+                model_id="m", model_sha256="a" * 64,
+            )
+
+
+class TestL4LAnomalyScore:
+    @pytest.mark.parametrize("score", [0.0, 0.5, 1.0])
+    def test_bounds(self, score):
+        a = L4LAnomalyScore(
+            target_id="t", score=score,
+            model_id="m", model_sha256="a" * 64,
+        )
+        assert a.score == score
+
+    @pytest.mark.parametrize("score", [-0.01, 1.01, 10.0, -1.0])
+    def test_out_of_bounds_rejected(self, score):
+        with pytest.raises(ValidationError):
+            L4LAnomalyScore(
+                target_id="t", score=score,
+                model_id="m", model_sha256="a" * 64,
+            )
+
+
+class TestL4LProposal:
+    def test_draft_layer_accepted(self):
+        p = L4LProposal(
+            proposal_kind="geometry_suggestion",
+            target_layer="TOTaLi-SURV-BRKLN-DRAFT",
+            rationale="ml suggestion",
+            confidence=0.8,
+        )
+        assert p.target_layer.endswith("-DRAFT")
+
+    def test_qa_layer_accepted(self):
+        p = L4LProposal(
+            proposal_kind="classification_refinement",
+            target_layer="TOTaLi-QA-OCCLUSION",
+            rationale="anomaly flagged",
+            confidence=0.9,
+        )
+        assert p.target_layer.startswith("TOTaLi-QA-")
+
+    def test_no_target_layer_accepted(self):
+        p = L4LProposal(
+            proposal_kind="action_hint",
+            rationale="no layer required", confidence=0.5,
+        )
+        assert p.target_layer is None
+
+    @pytest.mark.parametrize(
+        "bad_layer",
+        ["SomeLayer", "TOTaLi-SURV-BRKLN", "MyOwn-DRAFT", "TOTaLi-SURV"],
+    )
+    def test_non_draft_non_qa_layer_rejected(self, bad_layer):
+        with pytest.raises(ValidationError):
+            L4LProposal(
+                proposal_kind="geometry_suggestion",
+                target_layer=bad_layer,
+                rationale="r", confidence=0.5,
+            )
+
+    @pytest.mark.parametrize("conf", [-0.01, 1.01])
+    def test_confidence_out_of_bounds_rejected(self, conf):
+        with pytest.raises(ValidationError):
+            L4LProposal(
+                proposal_kind="action_hint", rationale="r", confidence=conf,
+            )
+
+
+# ------------------------------------------------------------------------
+# Protocol surfaces
+# ------------------------------------------------------------------------
+
+class TestProtocols:
+    def test_auracad_adapter_has_expected_methods(self):
+        expected = {"read_cad", "heal_geometry", "transform_crs"}
+        actual = {
+            n for n, m in inspect.getmembers(AuracadAdapter, inspect.isfunction)
+            if not n.startswith("_")
+        }
+        assert expected <= actual, f"missing: {expected - actual}"
+
+    def test_l4l_adapter_has_expected_methods(self):
+        expected = {"embed_scene", "score_anomalies", "propose_actions"}
+        actual = {
+            n for n, m in inspect.getmembers(L4LInferenceAdapter, inspect.isfunction)
+            if not n.startswith("_")
+        }
+        assert expected <= actual, f"missing: {expected - actual}"

--- a/tests/test_import_smoke.py
+++ b/tests/test_import_smoke.py
@@ -27,6 +27,9 @@ PRODUCTION_MODULES = [
     "totali.pipeline.orchestrator",
     "totali.quarantine_ui.app",
     "totali.repl.contracts",
+    "totali.external",
+    "totali.external.auracad_contract",
+    "totali.external.l4l_contract",
 ]
 
 

--- a/totali/external/__init__.py
+++ b/totali/external/__init__.py
@@ -1,0 +1,49 @@
+"""External-service contracts: how TOTaLi consumes auracad, L4L, and other sibling projects.
+
+These modules are **contract surfaces only** — Pydantic models + Protocol
+definitions that pin what TOTaLi expects from its external dependencies.
+No actual RPC, FFI, or network code lives here. When the real integration
+lands (future feature branches), the implementing adapter will import from
+these contracts and be statically checkable against them.
+
+Invariants enforced by the contracts:
+
+- All external-service output carries `authoritative: bool = False` and
+  refuses any truthy value at construction (mirrors S-7 in
+  `totali/pipeline/models.py::ClassificationResult`).
+- Every response model carries a `schema_version` string so adapter drift
+  is explicit.
+- No external service has a direct mutation path into TOTaLi's pipeline.
+  Outputs enter the pipeline only through validator gates (e.g., the
+  `SurveyorLinter` `DRAFT`-layer discipline + PLS review).
+
+References:
+- `Docs/PRODUCTION_DESIGN_REFERENCE.md` — north-star architecture
+- `Docs/TOTALI_MAPPING_TO_PRODUCTION_DESIGN.md` §Integration — what TOTaLi owns vs siblings
+- Sibling projects: `~/Dev/auracad/docs/PRODUCTION_DESIGN_ALIGNMENT.md`,
+  `~/Dev/liberals4liberty/docs/PRODUCTION_DESIGN_ALIGNMENT.md`
+"""
+
+from totali.external.auracad_contract import (
+    AuracadAdapter,
+    AuracadHealReport,
+    AuracadReadReport,
+    AuracadTransformReport,
+)
+from totali.external.l4l_contract import (
+    L4LAnomalyScore,
+    L4LInferenceAdapter,
+    L4LProposal,
+    L4LSceneEmbedding,
+)
+
+__all__ = [
+    "AuracadAdapter",
+    "AuracadHealReport",
+    "AuracadReadReport",
+    "AuracadTransformReport",
+    "L4LAnomalyScore",
+    "L4LInferenceAdapter",
+    "L4LProposal",
+    "L4LSceneEmbedding",
+]

--- a/totali/external/auracad_contract.py
+++ b/totali/external/auracad_contract.py
@@ -1,0 +1,131 @@
+"""Contract surface for TOTaLi ↔ auracad integration.
+
+auracad is the deterministic native core (geometry kernel, scene graph, CAD I/O).
+TOTaLi expects three capabilities from auracad:
+
+1. DWG/DXF read — returns a schema-valid dict matching
+   `dwg-tool-parser/schema/parser_output.schema.json`.
+2. Geometry healing — polyline/polygon repair with quarantine reporting
+   (TOTaLi's shield can delegate to auracad's heavier-weight healer once the
+   FFI is wired).
+3. CRS transform — must route through the same PROJ version TOTaLi uses.
+
+This module defines the contract only. The real adapter (FFI or subprocess
+bridge) lives in a future feature branch and must satisfy the
+`AuracadAdapter` Protocol.
+
+See `~/Dev/auracad/docs/PRODUCTION_DESIGN_ALIGNMENT.md` for auracad's side
+of the contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+# Frozen contract version. Bump MAJOR when breaking; MINOR for additive fields.
+AURACAD_CONTRACT_VERSION = "1.0.0"
+
+
+class AuracadReadReport(BaseModel):
+    """Output of `AuracadAdapter.read_cad(path)`. Must validate against
+    `dwg-tool-parser/schema/parser_output.schema.json`.
+
+    auracad is authoritative for the geometry it returns; this report is
+    consumed by TOTaLi's `cad_shielding` phase as input to the healer.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = Field(default=AURACAD_CONTRACT_VERSION)
+    file: str
+    format: str  # dxf | dwg
+    version: str | None = None
+    layers: list[dict[str, Any]] = Field(default_factory=list)
+    entities: list[dict[str, Any]] = Field(default_factory=list)
+    blocks: list[dict[str, Any]] = Field(default_factory=list)
+    survey_tags: list[dict[str, Any]] = Field(default_factory=list)
+    errors: list[dict[str, Any]] = Field(default_factory=list)
+
+    @field_validator("format")
+    @classmethod
+    def _known_format(cls, v: str) -> str:
+        if v not in {"dxf", "dwg"}:
+            raise ValueError(f"format must be 'dxf' or 'dwg', got {v!r}")
+        return v
+
+
+class AuracadHealReport(BaseModel):
+    """Result of `AuracadAdapter.heal_geometry(...)`.
+
+    Quarantine counts and healing stats. TOTaLi's shield emits a `heal` audit
+    event with these values — keep field names stable across versions.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = Field(default=AURACAD_CONTRACT_VERSION)
+    input_entity_count: int = Field(ge=0)
+    healed_count: int = Field(ge=0)
+    quarantined_count: int = Field(ge=0)
+    passed_count: int = Field(ge=0)
+    issues: list[str] = Field(default_factory=list)
+    quarantined_ids: list[str] = Field(default_factory=list)
+
+
+class AuracadTransformReport(BaseModel):
+    """Result of `AuracadAdapter.transform_crs(xyz, source_epsg, target_epsg)`.
+
+    The transform itself must use the same PROJ version TOTaLi does — the
+    report records the actual PROJ version used so TOTaLi can detect drift
+    and emit a `transform` audit event with matching metadata.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = Field(default=AURACAD_CONTRACT_VERSION)
+    source_epsg: int
+    target_epsg: int
+    proj_version: str  # e.g. "9.4.1"
+    point_count: int = Field(ge=0)
+    bounds_pre: tuple[float, float, float, float, float, float] | None = None
+    bounds_post: tuple[float, float, float, float, float, float] | None = None
+
+
+class AuracadAdapter(Protocol):
+    """The runtime contract an auracad adapter must satisfy.
+
+    Implementations (future feature branches) may be:
+    - C FFI wrappers via `ctypes` / `cffi`
+    - pybind11 Python modules
+    - Subprocess bridges emitting JSON over stdout
+
+    Whatever the transport, the interface is the same.
+    """
+
+    def read_cad(self, path: str) -> AuracadReadReport:
+        """Read a DWG/DXF file; return schema-valid report. Raises on I/O or
+        parse failure — never returns silently incomplete data."""
+        ...
+
+    def heal_geometry(
+        self,
+        polylines: list[list[tuple[float, float, float]]],
+        tolerance: float,
+    ) -> AuracadHealReport:
+        """Heal a batch of polylines. Tolerance is the close/snap threshold in
+        coordinate units. Unhealable geometry goes to `quarantined_ids`, never
+        into the returned healed set."""
+        ...
+
+    def transform_crs(
+        self,
+        xyz: list[tuple[float, float, float]],
+        source_epsg: int,
+        target_epsg: int,
+    ) -> AuracadTransformReport:
+        """CRS-to-CRS transform. MUST use the same PROJ version TOTaLi does;
+        the returned `proj_version` lets TOTaLi detect drift."""
+        ...

--- a/totali/external/l4l_contract.py
+++ b/totali/external/l4l_contract.py
@@ -1,0 +1,148 @@
+"""Contract surface for TOTaLi ↔ L4L integration.
+
+L4L is the generative/simulation/JEPA layer — **advisory only** per the
+production-design invariant (JEPA output is never authoritative).
+
+TOTaLi's potential consumption paths:
+
+1. JEPA scene embeddings for retrieval / anomaly ranking at surveyor-lint
+   time (augments `SurveyorLinter._confidence_color` with ML signal).
+2. L4L's generative proposals for CAD objects — surfaced as DRAFT-layer
+   suggestions, never auto-applied.
+
+This module defines the contract only. Every output carries
+`authoritative=False` with a constructor guard; truthy assignment raises at
+construction, mirroring `ClassificationResult.authoritative` (S-7).
+
+See `~/Dev/liberals4liberty/docs/PRODUCTION_DESIGN_ALIGNMENT.md` for L4L's
+side of the contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+# Frozen contract version. Bump MAJOR when breaking; MINOR for additive fields.
+L4L_CONTRACT_VERSION = "1.0.0"
+
+
+class _NonAuthoritativeBase(BaseModel):
+    """Base class for all L4L outputs. Enforces §1.3 invariant:
+    authoritative is False, always. A truthy value raises at construction.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = Field(default=L4L_CONTRACT_VERSION)
+    authoritative: bool = False
+
+    @field_validator("authoritative")
+    @classmethod
+    def _must_be_false(cls, v: bool) -> bool:
+        if v is not False:
+            raise ValueError(
+                "L4L output is never authoritative. TOTaLi §1.3 invariant: "
+                "ML output lands only on DRAFT layers and requires PLS review."
+            )
+        return v
+
+
+class L4LSceneEmbedding(_NonAuthoritativeBase):
+    """A scene-level embedding produced by L4L's JEPA.
+
+    `space` indicates which embedding space (per the design:
+    scene_global / tile_visual / object_semantic / object_geometry /
+    command_context / code_module).
+    `vector` is unit-normalized; dimension pinned per space at adapter level.
+    """
+
+    space: str
+    vector_len: int = Field(ge=1)
+    model_id: str
+    model_sha256: str = Field(min_length=64, max_length=64)
+
+    @field_validator("space")
+    @classmethod
+    def _known_space(cls, v: str) -> str:
+        allowed = {
+            "scene_global",
+            "tile_visual",
+            "object_semantic",
+            "object_geometry",
+            "command_context",
+            "code_module",
+        }
+        if v not in allowed:
+            raise ValueError(f"unknown embedding space {v!r}; allowed: {sorted(allowed)}")
+        return v
+
+
+class L4LAnomalyScore(_NonAuthoritativeBase):
+    """Anomaly score for a scene region or object.
+
+    Score is bounded [0, 1]. Use as an additional input to surveyor-lint
+    confidence coloring; never as a promotion gate.
+    """
+
+    target_id: str  # scene object / tile / classification-segment ID
+    score: float = Field(ge=0.0, le=1.0)
+    model_id: str
+    model_sha256: str = Field(min_length=64, max_length=64)
+
+
+class L4LProposal(_NonAuthoritativeBase):
+    """A generative proposal from L4L for an action or geometry addition.
+
+    Emitted as a ranked candidate for the orchestrator's next-best-action
+    ranking. TOTaLi surfaces top-k as DRAFT-layer suggestions; surveyors
+    accept/reject/defer per L-5.
+    """
+
+    proposal_kind: str  # "geometry_suggestion" | "classification_refinement" | "action_hint"
+    target_layer: str | None = None  # must end in -DRAFT if set
+    rationale: str
+    confidence: float = Field(ge=0.0, le=1.0)
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("target_layer")
+    @classmethod
+    def _must_be_draft_or_qa(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        # TOTaLi §1.3 invariant mirror: layer names must match the canonical
+        # pattern TOTaLi-<DISC>-<FEAT>-DRAFT or the TOTaLi-QA-* exemption.
+        if v.startswith("TOTaLi-QA-"):
+            return v
+        if v.startswith("TOTaLi-") and v.endswith("-DRAFT"):
+            return v
+        raise ValueError(
+            f"target_layer={v!r} must be TOTaLi-<DISC>-<FEAT>-DRAFT or TOTaLi-QA-*"
+        )
+
+
+class L4LInferenceAdapter(Protocol):
+    """The runtime contract an L4L inference adapter must satisfy.
+
+    Implementations (future feature branches) may be:
+    - ONNX runtime loading via `totali.models.loader.load_onnx` (preferred)
+    - Subprocess RPC to L4L-Intelligence service
+    - In-process pybind11 binding
+
+    Whatever the transport, every output is a non-authoritative Pydantic model.
+    """
+
+    def embed_scene(self, context: dict[str, Any]) -> L4LSceneEmbedding:
+        """Produce a `scene_global` embedding for the given context."""
+        ...
+
+    def score_anomalies(self, targets: list[str]) -> list[L4LAnomalyScore]:
+        """Score a batch of targets [0,1]. No side effects beyond the model call."""
+        ...
+
+    def propose_actions(self, context: dict[str, Any], top_k: int = 5) -> list[L4LProposal]:
+        """Return up to top_k ranked proposals. Top_k capped at adapter-level
+        limit (suggestion: 10). Never promotes geometry to certified."""
+        ...


### PR DESCRIPTION
## Summary

Closes the loop on cross-project work. Two sibling-project alignment docs landed in parallel (auracad + L4L), and this PR adds the **executable contract** TOTaLi will use to consume them.

`totali/external/` is contract-surface only — Pydantic models + Protocol definitions. No RPC / FFI / network code yet; future adapter implementations will be statically checkable against these contracts.

## Cross-project work that landed in parallel

- **`~/Dev/auracad/docs/PRODUCTION_DESIGN_ALIGNMENT.md`** — auracad as the deterministic native core; geometry-kernel phase ordering; FFI rules; performance targets. (On `agentic/production-design-alignment-2026-04-23` branch in auracad; pushed to remote but auracad's GitHub repo state is too sparse for a meaningful PR — branch is preserved for reconciliation.)
- **`~/Dev/auracad/docs/CXX_AGENTIC_RULES.md`** — direct port of TOTaLi's C++ rules adapted for auracad's C++-native stance.
- **`~/Dev/liberals4liberty/docs/PRODUCTION_DESIGN_ALIGNMENT.md`** — L4L's JEPA-as-advisory invariant; LNP deterministic-at-boundary; L4L → auracad C FFI contract; safety matrix. (Local-only; L4L has no accessible GitHub remote.)

## Modules in this PR

### `totali/external/auracad_contract.py`
- `AURACAD_CONTRACT_VERSION = "1.0.0"`
- `AuracadReadReport` — schema-valid DWG/DXF read output (matches `dwg-tool-parser/schema/parser_output.schema.json`)
- `AuracadHealReport` — polyline/polygon healing + quarantine stats
- `AuracadTransformReport` — CRS transform with PROJ-version metadata for drift detection
- `AuracadAdapter` Protocol — `read_cad` / `heal_geometry` / `transform_crs`

### `totali/external/l4l_contract.py`
- `L4L_CONTRACT_VERSION = "1.0.0"`
- `_NonAuthoritativeBase` — enforces `authoritative=False` at construction; truthy raises (mirrors S-7 `ClassificationResult` invariant)
- `L4LSceneEmbedding` — 6 embedding spaces (scene_global / tile_visual / object_semantic / object_geometry / command_context / code_module)
- `L4LAnomalyScore` — bounded [0, 1]
- `L4LProposal` — `target_layer` must be `TOTaLi-<DISC>-<FEAT>-DRAFT` or `TOTaLi-QA-*` (mirrors C-3 layer-name guard)
- `L4LInferenceAdapter` Protocol — `embed_scene` / `score_anomalies` / `propose_actions`

## Invariants enforced (cross-platform mirror of TOTaLi §1)

- Every L4L output `authoritative=False`; truthy raises at construction (S-7 mirror)
- L4L proposal `target_layer` enforces -DRAFT discipline (C-3 mirror)
- Anomaly + confidence scores bounded [0, 1]
- ONNX `model_sha256` length pinned at 64 hex chars (M-1 mirror)
- Pydantic `ConfigDict(extra="forbid")` on every model — adapter drift fails fast

## Tests

`tests/test_external_contracts.py` — 55 tests across 9 classes:
- Version pins
- Auracad read-report format enum + extra-field rejection
- Auracad heal-report non-negative count enforcement
- L4L authoritative-invariant parametrized over all 3 models × 3 truthy values
- Embedding space allowlist
- sha256 length
- Layer-name discipline (DRAFT or QA prefix required)
- Anomaly + confidence bounds
- Protocol method-presence introspection

Plus 3 entries added to `test_import_smoke.py` for the new modules.

## Test plan

- [x] `pytest -q` — 711 passed / 1 skipped / 0 failed (was 653)
- [x] `ruff check totali/ tests/` — clean
- [x] No production-code changes outside `totali/external/` and 1 test file
- [x] No conflicts with `origin/main`

## Why contracts now (when there's no implementation yet)

Production design's lesson #1: define the contract before the integration. When the auracad C FFI bridge or the L4L ONNX inference path lands in TOTaLi, the implementer has a Pydantic model to construct against and a Protocol to satisfy. Adapter drift is caught at construction time, not in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new contract-only Pydantic models/Protocols and associated tests, with no behavioral changes to existing pipeline execution or any new external I/O paths.
> 
> **Overview**
> Adds a new `totali.external` package that defines **contract surfaces** (Pydantic models + `Protocol`s) for future `auracad` and `L4L` integrations, including pinned `schema_version`s, strict `extra="forbid"` validation, and an enforced **non-authoritative** (`authoritative=False`) invariant for all L4L outputs.
> 
> Introduces comprehensive contract-shape tests covering version pins, enum/bounds validation, layer-name constraints for L4L proposals, and adapter method-surface checks, and extends the import-smoke test to include the new modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf703d82622fbb08032eb5da8c5a4bfe722fd8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->