### PR TITLE
feat(external): Phase 2 — live StubL4LInferenceAdapter (+34 tests)

### DIFF
--- a/tests/test_l4l_adapter_stub.py
+++ b/tests/test_l4l_adapter_stub.py
@@ -1,0 +1,312 @@
+"""Tests for :class:`totali.external.l4l_adapter_stub.StubL4LInferenceAdapter`.
+
+Phase 2 of the L4L integration roll-out: a local, deterministic stub that
+satisfies the :class:`L4LInferenceAdapter` Protocol so TOTaLi-side callers
+can be built and regression-tested before the real L4L-Intelligence ONNX
+service lands.
+
+These tests assert:
+
+* the stub structurally satisfies the :class:`L4LInferenceAdapter`
+  Protocol (the Protocol is not ``@runtime_checkable``, same as
+  ``AuracadAdapter``) — we probe each method by attribute + callability
+  rather than ``isinstance``,
+* ``embed_scene`` returns a well-formed :class:`L4LSceneEmbedding`,
+* ``score_anomalies`` is pure (deterministic per target_id) and bounded,
+* ``propose_actions`` respects the ``top_k`` contract (0, negative, and
+  over-10 all clamp), marks every proposal as stub-origin via the
+  ``rationale`` field, and is deterministic per context,
+* the non-authoritative invariant holds across every output.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from totali.external.l4l_adapter_stub import StubL4LInferenceAdapter
+from totali.external.l4l_contract import (
+    L4LAnomalyScore,
+    L4LInferenceAdapter,
+    L4LProposal,
+    L4LSceneEmbedding,
+)
+
+_ALLOWED_PROPOSAL_KINDS = {
+    "geometry_suggestion",
+    "classification_refinement",
+    "action_hint",
+}
+
+
+@pytest.fixture
+def adapter() -> StubL4LInferenceAdapter:
+    return StubL4LInferenceAdapter()
+
+
+# ===================================================================
+# 1. Protocol conformance
+# ===================================================================
+
+
+class TestProtocolConformance:
+    """``StubL4LInferenceAdapter`` structurally satisfies
+    :class:`L4LInferenceAdapter`.
+
+    The Protocol is not decorated ``@runtime_checkable`` — ``isinstance``
+    against a bare Protocol raises ``TypeError``. We instead probe each
+    method name for presence + callability.
+    """
+
+    _PROTOCOL_METHODS = ("embed_scene", "score_anomalies", "propose_actions")
+
+    def test_instance_exposes_all_protocol_methods(self, adapter):
+        for name in self._PROTOCOL_METHODS:
+            attr = getattr(adapter, name, None)
+            assert attr is not None, f"missing Protocol method {name!r}"
+            assert callable(attr), f"{name!r} is not callable"
+
+    def test_protocol_itself_declares_expected_methods(self):
+        for name in self._PROTOCOL_METHODS:
+            assert hasattr(L4LInferenceAdapter, name), (
+                f"L4LInferenceAdapter Protocol lost method {name!r}"
+            )
+
+    def test_isinstance_with_runtime_checkable_would_require_decorator(self):
+        # Pins current non-runtime-checkable status. If someone later adds
+        # @runtime_checkable to L4LInferenceAdapter, this test will start
+        # failing and signal that conformance probing here should be
+        # upgraded to a real ``isinstance`` check.
+        with pytest.raises(TypeError):
+            isinstance(StubL4LInferenceAdapter(), L4LInferenceAdapter)
+
+
+# ===================================================================
+# 2. embed_scene
+# ===================================================================
+
+
+class TestEmbedScene:
+    def test_returns_scene_embedding(self, adapter):
+        emb = adapter.embed_scene({"tile_id": "t1"})
+        assert isinstance(emb, L4LSceneEmbedding)
+
+    def test_space_is_scene_global(self, adapter):
+        emb = adapter.embed_scene({"tile_id": "t1"})
+        assert emb.space == "scene_global"
+
+    def test_vector_len_positive(self, adapter):
+        emb = adapter.embed_scene({"tile_id": "t1"})
+        assert emb.vector_len > 0
+
+    def test_non_authoritative(self, adapter):
+        emb = adapter.embed_scene({"tile_id": "t1"})
+        assert emb.authoritative is False
+
+    def test_model_sha256_is_64_hex_chars(self, adapter):
+        emb = adapter.embed_scene({"tile_id": "t1"})
+        assert len(emb.model_sha256) == 64
+        # All hex digits (str.isalnum is too loose; check explicitly).
+        assert all(c in "0123456789abcdef" for c in emb.model_sha256)
+
+    def test_deterministic_across_calls(self, adapter):
+        """Same adapter instance, same context, twice → identical embedding."""
+        ctx = {"tile_id": "t1", "extent": [0, 0, 100, 100]}
+        e1 = adapter.embed_scene(ctx)
+        e2 = adapter.embed_scene(ctx)
+        assert e1.model_sha256 == e2.model_sha256
+        assert e1.space == e2.space
+        assert e1.vector_len == e2.vector_len
+
+    def test_deterministic_across_instances(self):
+        """Fresh adapters produce the same embedding for the same context.
+
+        Note: the stub is currently context-blind — embedding fields do not
+        vary with `context`. This test pins that property intentionally so
+        cross-instance determinism is guaranteed, AND so a future real
+        adapter that starts responding to context cannot silently regress
+        this property without updating the test.
+        """
+        a1 = StubL4LInferenceAdapter()
+        a2 = StubL4LInferenceAdapter()
+        ctx = {"tile_id": "shared"}
+        e1 = a1.embed_scene(ctx)
+        e2 = a2.embed_scene(ctx)
+        assert e1.model_sha256 == e2.model_sha256
+        assert e1.space == e2.space
+        assert e1.vector_len == e2.vector_len
+        assert e1.model_id == e2.model_id
+
+    def test_context_blind_is_documented_stub_limitation(self, adapter):
+        """Documented stub limitation: embedding fields do not vary with
+        context. The real L4L service will produce context-dependent
+        embeddings; this test pins the current stub behavior so the
+        limitation is obvious and the next adapter version must update
+        this test deliberately."""
+        e1 = adapter.embed_scene({"tile_id": "a"})
+        e2 = adapter.embed_scene({"tile_id": "b", "extent": [1, 2, 3, 4]})
+        # Same pinned fields — stub is context-blind by design.
+        assert e1.model_sha256 == e2.model_sha256
+        assert e1.vector_len == e2.vector_len
+        assert e1.space == e2.space
+
+
+# ===================================================================
+# 3. score_anomalies
+# ===================================================================
+
+
+class TestScoreAnomalies:
+    def test_returns_one_per_target(self, adapter):
+        scores = adapter.score_anomalies(["obj-1", "obj-2", "obj-3"])
+        assert len(scores) == 3
+        for s in scores:
+            assert isinstance(s, L4LAnomalyScore)
+
+    def test_all_non_authoritative(self, adapter):
+        scores = adapter.score_anomalies(["obj-1", "obj-2", "obj-3"])
+        for s in scores:
+            assert s.authoritative is False
+
+    def test_all_bounded_zero_to_one(self, adapter):
+        scores = adapter.score_anomalies(["obj-1", "obj-2", "obj-3"])
+        for s in scores:
+            assert 0.0 <= s.score <= 1.0
+
+    def test_empty_targets_returns_empty(self, adapter):
+        assert adapter.score_anomalies([]) == []
+
+    def test_deterministic_across_calls(self, adapter):
+        first = adapter.score_anomalies(["obj-1", "obj-2", "obj-3"])
+        second = adapter.score_anomalies(["obj-1", "obj-2", "obj-3"])
+        assert [s.score for s in first] == [s.score for s in second]
+        assert [s.target_id for s in first] == [s.target_id for s in second]
+
+    def test_deterministic_across_instances(self):
+        a = StubL4LInferenceAdapter()
+        b = StubL4LInferenceAdapter()
+        sa = a.score_anomalies(["x", "y", "z"])
+        sb = b.score_anomalies(["x", "y", "z"])
+        assert [s.score for s in sa] == [s.score for s in sb]
+
+    def test_target_id_preserved(self, adapter):
+        scores = adapter.score_anomalies(["alpha", "beta"])
+        assert [s.target_id for s in scores] == ["alpha", "beta"]
+
+
+# ===================================================================
+# 4. propose_actions
+# ===================================================================
+
+
+class TestProposeActions:
+    def test_default_top_k_is_five(self, adapter):
+        proposals = adapter.propose_actions({"tile_id": "t1"})
+        assert len(proposals) == 5
+
+    def test_all_are_l4l_proposals(self, adapter):
+        proposals = adapter.propose_actions({"tile_id": "t1"})
+        for p in proposals:
+            assert isinstance(p, L4LProposal)
+
+    def test_top_k_zero_returns_empty(self, adapter):
+        assert adapter.propose_actions({"tile_id": "t1"}, top_k=0) == []
+
+    def test_top_k_negative_returns_empty(self, adapter):
+        assert adapter.propose_actions({"tile_id": "t1"}, top_k=-1) == []
+        assert adapter.propose_actions({"tile_id": "t1"}, top_k=-100) == []
+
+    def test_top_k_above_ten_capped(self, adapter):
+        assert len(adapter.propose_actions({"tile_id": "t1"}, top_k=11)) == 10
+        assert len(adapter.propose_actions({"tile_id": "t1"}, top_k=1000)) == 10
+
+    def test_top_k_exactly_ten_returns_ten(self, adapter):
+        assert len(adapter.propose_actions({"tile_id": "t1"}, top_k=10)) == 10
+
+    def test_all_non_authoritative(self, adapter):
+        proposals = adapter.propose_actions({"tile_id": "t1"}, top_k=10)
+        for p in proposals:
+            assert p.authoritative is False
+
+    def test_target_layer_shape(self, adapter):
+        # The Pydantic validator on L4LProposal already rejects malformed
+        # target_layer values at construction, so merely getting here proves
+        # each one is valid. We re-check to make the invariant explicit.
+        proposals = adapter.propose_actions({"tile_id": "t1"}, top_k=10)
+        for p in proposals:
+            if p.target_layer is None:
+                continue
+            assert (
+                p.target_layer.startswith("TOTaLi-QA-")
+                or (
+                    p.target_layer.startswith("TOTaLi-")
+                    and p.target_layer.endswith("-DRAFT")
+                )
+            ), f"unexpected target_layer={p.target_layer!r}"
+
+    def test_rationale_marks_stub_origin(self, adapter):
+        proposals = adapter.propose_actions({"tile_id": "t1"}, top_k=10)
+        for p in proposals:
+            assert "stub" in p.rationale.lower(), (
+                f"rationale must flag stub origin; got {p.rationale!r}"
+            )
+
+    def test_proposal_kind_in_allowed_set(self, adapter):
+        proposals = adapter.propose_actions({"tile_id": "t1"}, top_k=10)
+        for p in proposals:
+            assert p.proposal_kind in _ALLOWED_PROPOSAL_KINDS
+
+    def test_confidence_bounded(self, adapter):
+        proposals = adapter.propose_actions({"tile_id": "t1"}, top_k=10)
+        for p in proposals:
+            assert 0.0 <= p.confidence <= 1.0
+
+    def test_deterministic_same_context(self, adapter):
+        ctx = {"tile_id": "t1", "scene": "alpha"}
+        first = adapter.propose_actions(ctx, top_k=5)
+        second = adapter.propose_actions(ctx, top_k=5)
+        assert [
+            (p.proposal_kind, p.confidence, p.target_layer, p.rationale)
+            for p in first
+        ] == [
+            (p.proposal_kind, p.confidence, p.target_layer, p.rationale)
+            for p in second
+        ]
+
+    def test_deterministic_across_instances(self):
+        a = StubL4LInferenceAdapter()
+        b = StubL4LInferenceAdapter()
+        ctx = {"tile_id": "t42"}
+        pa = a.propose_actions(ctx, top_k=7)
+        pb = b.propose_actions(ctx, top_k=7)
+        assert [
+            (p.proposal_kind, p.confidence, p.target_layer) for p in pa
+        ] == [
+            (p.proposal_kind, p.confidence, p.target_layer) for p in pb
+        ]
+
+
+# ===================================================================
+# 5. Non-authoritative invariant
+# ===================================================================
+
+
+class TestNonAuthoritativeInvariant:
+    """Spot-check the §1.3 invariant at adapter-output level.
+
+    Every L4L output model already enforces ``authoritative=False`` via a
+    field validator, but this test pins the behaviour at the adapter
+    boundary so any future "improvement" that slips a truthy value past
+    the validator (e.g. by bypassing Pydantic construction) trips here.
+    """
+
+    def test_embedding_is_non_authoritative(self, adapter):
+        emb = adapter.embed_scene({"tile_id": "t1"})
+        assert emb.authoritative is False
+
+    def test_anomaly_scores_are_non_authoritative(self, adapter):
+        for s in adapter.score_anomalies(["obj-1"]):
+            assert s.authoritative is False
+
+    def test_proposals_are_non_authoritative(self, adapter):
+        for p in adapter.propose_actions({"tile_id": "t1"}, top_k=3):
+            assert p.authoritative is False

--- a/totali/external/l4l_adapter_stub.py
+++ b/totali/external/l4l_adapter_stub.py
@@ -1,0 +1,227 @@
+"""Local deterministic stub for ``L4LInferenceAdapter`` (Phase 2).
+
+This is the first concrete implementation of the
+:class:`~totali.external.l4l_contract.L4LInferenceAdapter` Protocol. It is
+**not** a real JEPA — it exists so TOTaLi-side callers (surveyor-lint ML
+augmentation, draft-layer proposal surfacing, next-best-action ranking)
+can be written and regression-tested against a well-formed contract
+surface before the real L4L-Intelligence ONNX service lands.
+
+Design requirements:
+
+* Every method is deterministic — same input, bit-identical output, across
+  calls and across fresh adapter instances. No wall-clock, no unseeded
+  RNG. ``hashlib.sha256`` is the determinism primitive.
+* Every output inherits from
+  :class:`~totali.external.l4l_contract._NonAuthoritativeBase`, so any
+  attempt to mark an artifact authoritative trips a Pydantic validator at
+  construction time.
+* ``rationale`` on every proposal contains the substring ``stub`` so
+  downstream consumers can reliably distinguish stub-origin artifacts
+  from real-model output during integration testing.
+
+When the real L4L-Intelligence service lands (ONNX runtime or subprocess
+RPC), it will implement the same ``L4LInferenceAdapter`` Protocol;
+callers will not need to change. This adapter is intentionally **not**
+exported from :mod:`totali.external.__init__` — that module is the
+frozen contract-surface index. Consumers import this concrete class
+explicitly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from totali.external.l4l_contract import (
+    L4LAnomalyScore,
+    L4LProposal,
+    L4LSceneEmbedding,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level stub-model identity
+# ---------------------------------------------------------------------------
+#
+# The stub advertises a fixed model_id / model_sha256 pair so callers see a
+# stable "which model did this come from?" signal. The sha256 is the hash of
+# a constant sentinel string — this is hardcoded (by being derived from a
+# constant at import time) so it never depends on filesystem path, env, or
+# install location, and so re-running the tests from any checkout yields
+# the same value. Swapping the sentinel string is a deliberate version
+# bump.
+
+_STUB_MODEL_ID = "stub-jepa"
+_STUB_MODEL_SENTINEL = b"totali.external.l4l_adapter_stub::StubL4LInferenceAdapter::v1"
+_STUB_MODEL_SHA256 = hashlib.sha256(_STUB_MODEL_SENTINEL).hexdigest()
+
+# Embedding-space dimension. The Protocol does not pin this — the real
+# JEPA will use 512 or 768. 128 is fine for the stub and keeps logs small.
+_STUB_VECTOR_LEN = 128
+
+# Adapter-level cap on ``top_k`` per the Protocol suggestion in
+# ``l4l_contract.L4LInferenceAdapter.propose_actions``.
+_TOP_K_MAX = 10
+
+# Rotated values for deterministic proposal construction. Order is fixed
+# and load-bearing — changing it changes stub output, which is a version
+# bump of the stub.
+_PROPOSAL_KINDS = (
+    "geometry_suggestion",
+    "classification_refinement",
+    "action_hint",
+)
+_TARGET_LAYERS: tuple[str | None, ...] = (
+    "TOTaLi-SURV-BOUNDARY-DRAFT",
+    "TOTaLi-SURV-MONUMENT-DRAFT",
+    "TOTaLi-QA-NOTES",
+    None,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _canonical_context_bytes(context: dict[str, Any]) -> bytes:
+    """Canonicalize a context dict to stable bytes for hashing.
+
+    ``sort_keys=True`` guarantees insertion-order independence. ``default=str``
+    guards against non-JSON-serializable values (e.g. ``Path``, ``UUID``)
+    without failing — the stub does not care about semantic fidelity of
+    the context, only that the same logical context yields the same bytes.
+    """
+
+    return json.dumps(context, sort_keys=True, default=str).encode("utf-8")
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _anomaly_score_for_target(target_id: str) -> float:
+    """Map a target_id to a deterministic score in ``[0.0, 1.0)``.
+
+    Takes the first 8 hex chars of ``sha256(target_id)`` as a 32-bit
+    unsigned int and normalizes by ``2**32`` (i.e. ``(1 << 32)``) — NOT
+    ``0xFFFFFFFF``. Using ``2**32`` as the denominator gives a uniform
+    distribution over ``2^32`` distinct buckets in the half-open interval
+    ``[0.0, 1.0)``; dividing by ``0xFFFFFFFF`` instead would create a
+    single over-represented endpoint at exactly 1.0 for one specific
+    digest prefix, which is neither uniform nor what callers expect.
+
+    The clamp below is purely defensive — with this denominator no
+    arithmetic can exceed 1.0 — but stays in place so future tweaks to
+    the formula (e.g., combining multiple hash slices) cannot silently
+    overflow the ``L4LAnomalyScore.score`` ``le=1.0`` Pydantic bound.
+    """
+
+    digest_hex = hashlib.sha256(target_id.encode("utf-8")).hexdigest()
+    raw = int(digest_hex[:8], 16) / (1 << 32)
+    return max(0.0, min(1.0, raw))
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class StubL4LInferenceAdapter:
+    """Local stub implementation of L4LInferenceAdapter Protocol.
+
+    Emits deterministic, well-formed, non-authoritative artifacts suitable
+    for contract validation and TOTaLi-side integration tests. NOT a real
+    JEPA — just enough to satisfy the Protocol and prove callers handle
+    the contract correctly.
+
+    When the real L4L-Intelligence ONNX service lands, it will implement
+    the same L4LInferenceAdapter Protocol; callers will not need to change.
+    """
+
+    def embed_scene(self, context: dict[str, Any]) -> L4LSceneEmbedding:
+        """Produce a deterministic ``scene_global`` embedding.
+
+        The context is accepted for Protocol conformance; the stub does
+        not vary ``vector_len`` / ``model_id`` with it (those are module
+        constants). Callers that need to distinguish two scenes by their
+        embedding metadata should switch to the real adapter.
+        """
+
+        return L4LSceneEmbedding(
+            space="scene_global",
+            vector_len=_STUB_VECTOR_LEN,
+            model_id=_STUB_MODEL_ID,
+            model_sha256=_STUB_MODEL_SHA256,
+        )
+
+    def score_anomalies(self, targets: list[str]) -> list[L4LAnomalyScore]:
+        """Return one deterministic score per target, preserving order.
+
+        The score is a normalized sha256-prefix, so the mapping
+        ``target_id -> score`` is stable for the lifetime of this stub
+        version.
+        """
+
+        return [
+            L4LAnomalyScore(
+                target_id=target_id,
+                score=_anomaly_score_for_target(target_id),
+                model_id=_STUB_MODEL_ID,
+                model_sha256=_STUB_MODEL_SHA256,
+            )
+            for target_id in targets
+        ]
+
+    def propose_actions(
+        self,
+        context: dict[str, Any],
+        top_k: int = 5,
+    ) -> list[L4LProposal]:
+        """Return up to ``top_k`` deterministic proposals.
+
+        Bounds:
+
+        * ``top_k <= 0`` → empty list
+        * ``top_k > 10`` → clamped to 10 (Protocol-level suggested cap)
+
+        Proposal properties are derived from a sha256 over the canonical
+        context bytes plus a per-slot index so successive proposals in a
+        single call differ from each other, and every proposal carries
+        ``"stub"`` in its rationale.
+        """
+
+        if top_k <= 0:
+            return []
+        k = min(top_k, _TOP_K_MAX)
+
+        context_digest = _sha256_hex(_canonical_context_bytes(context))
+
+        proposals: list[L4LProposal] = []
+        for i in range(k):
+            # Mix the slot index into the seed so proposals within a
+            # single call are distinct yet still deterministic per
+            # (context, slot) pair.
+            slot_seed = _sha256_hex(
+                f"{context_digest}:{i}".encode("utf-8")
+            )
+            # Denominator is ``2**32`` for uniform ``[0.0, 1.0)`` — see
+            # _anomaly_score_for_target for the rationale on the choice.
+            confidence = int(slot_seed[:8], 16) / (1 << 32)
+            proposal_kind = _PROPOSAL_KINDS[i % len(_PROPOSAL_KINDS)]
+            target_layer = _TARGET_LAYERS[i % len(_TARGET_LAYERS)]
+
+            proposals.append(
+                L4LProposal(
+                    proposal_kind=proposal_kind,
+                    target_layer=target_layer,
+                    rationale=(
+                        f"{type(self).__name__} stub proposal #{i} "
+                        f"(context_digest={context_digest[:12]}...)"
+                    ),
+                    confidence=max(0.0, min(1.0, confidence)),
+                    payload={"slot": i, "seed": slot_seed[:16]},
+                )
+            )
+        return proposals


### PR DESCRIPTION
## Summary

Phase 2 of the external-contract integration plan. Mirrors Phase 1 (#101): ships a concrete deterministic stub implementation of `L4LInferenceAdapter` that makes the Pydantic contract executable on the L4L side too.

Executed via `superpowers:subagent-driven-development`: implementer → spec review (✅) → code quality review (2 Important issues flagged) → fix → re-review (✅ APPROVED).

**Net: 1 commit, 724 → 758 passed (+34), ruff clean, zero remaining blockers.**

## What landed

### `totali/external/l4l_adapter_stub.py` (new)

`StubL4LInferenceAdapter` satisfies `L4LInferenceAdapter` Protocol:

- **`embed_scene(context) -> L4LSceneEmbedding`** — returns fixed `scene_global` embedding with module-versioned `model_sha256` (computed from `"totali.external.l4l_adapter_stub::StubL4LInferenceAdapter::v1"`). Context-blind by design (stub limitation, documented + tested).
- **`score_anomalies(targets) -> list[L4LAnomalyScore]`** — deterministic score per target via `sha256(target_id)` → first 8 hex chars → `int / (1 << 32)` → uniform `[0.0, 1.0)`.
- **`propose_actions(context, top_k=5) -> list[L4LProposal]`** — canonical context digest via `json.dumps(sort_keys=True, default=str)` → sha256, per-slot seeds `sha256(f"{digest}:{i}")`. `top_k <= 0 → []`; `top_k > 10` capped to 10 per Protocol limit suggestion. Rotates `proposal_kind` and `target_layer` through valid values; rationale always contains "stub" so consumers can identify stub-origin artifacts during integration tests.

All outputs inherit `_NonAuthoritativeBase.authoritative = False` from the contract layer — any attempt to construct with `authoritative=True` raises `ValidationError`. The stub cannot forge authority.

**Deliberately not in `totali/external/__init__.py`** — concrete implementations stay out of the contract-surface index (matches Phase 1 pattern).

### `tests/test_l4l_adapter_stub.py` (new) — 34 tests across 5 classes

- `TestProtocolConformance` — callable-attribute probe; pins current non-`@runtime_checkable` status via `TypeError` assertion on `isinstance`.
- `TestEmbedScene` — return type, fields, sha256 length, **determinism across calls and instances**, and a pinned "stub is context-blind" regression net.
- `TestScoreAnomalies` — list shape, non-authoritative, bounded `[0, 1]`, empty → empty, determinism across calls + fresh instances.
- `TestProposeActions` — `top_k` bounds (`0, -1, 5, 11, 1000`), non-authoritative, layer-name discipline, rationale contains "stub", `proposal_kind` allowlist, determinism.
- `TestNonAuthoritativeInvariant` — explicit belt-and-suspenders check on one of each output type.

## Subagent-driven workflow evidence

| Stage | Subagent | Outcome |
|---|---|---|
| Implementer | `general-purpose` | DONE, +31 initial tests, sha256-based determinism |
| Spec compliance | `feature-dev:code-reviewer` | `SPEC_COMPLIANT: YES` |
| Code quality (round 1) | `feature-dev:code-reviewer` | 2 Important: (a) denominator ambiguity `0xFFFFFFFF` vs `(1 << 32)`; (b) missing `embed_scene` determinism tests |
| Fix | controller inline | denominator → `(1 << 32)` with docstring rationale; +3 determinism tests for `embed_scene` |
| Code quality (round 2) | `feature-dev:code-reviewer` | `APPROVED` |

## Why the denominator change matters

Using `0xFFFFFFFF` as divisor means the digest prefix `0xFFFFFFFF` maps to exactly `1.0` while every other value maps strictly below — one over-represented endpoint, not uniform. Switching to `(1 << 32)` gives a proper uniform distribution over `2^32` buckets in the half-open `[0.0, 1.0)` interval, which is the mathematically defensible choice for a "stub ML confidence" surrogate. Documented in both call sites.

## Test plan

- [x] `pytest -q` — 758 passed / 1 skipped / 0 failed (baseline 724)
- [x] `ruff check totali/ tests/` — clean
- [x] No production-code changes outside the new `l4l_adapter_stub.py`
- [x] `StubL4LInferenceAdapter` NOT in `totali/external/__init__.py` (contract-surface index stays frozen)
- [x] All 6 untouchable files unchanged (contract, auracad adapter, test_external_contracts, test_auracad_adapter_dxf)
- [x] Spec + code quality reviewers both approved

## What's now live on both sides

With #101 (auracad adapter) and this PR, `totali/external/` has:

| Contract | Concrete adapter | Status |
|---|---|---|
| `AuracadAdapter.read_cad` | `DxfAuracadAdapter` | ✅ real, via parse_dxf |
| `AuracadAdapter.heal_geometry` | `DxfAuracadAdapter` | stub (NotImplementedError; TOTaLi has its own CADShield healer) |
| `AuracadAdapter.transform_crs` | `DxfAuracadAdapter` | stub (NotImplementedError; use pyproj directly) |
| `L4LInferenceAdapter.embed_scene` | `StubL4LInferenceAdapter` | deterministic stub |
| `L4LInferenceAdapter.score_anomalies` | `StubL4LInferenceAdapter` | deterministic stub |
| `L4LInferenceAdapter.propose_actions` | `StubL4LInferenceAdapter` | deterministic stub |

Both sides executable; contracts are no longer aspirational. Future real-auracad FFI bridge and real-L4L ONNX service will implement the same Protocols and be statically checkable against the same Pydantic models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds a local stub adapter and new tests without modifying existing production behavior or contract definitions.
> 
> **Overview**
> Adds a new deterministic `StubL4LInferenceAdapter` implementation for the `L4LInferenceAdapter` Protocol, producing fixed `embed_scene` metadata, per-target hash-derived anomaly scores, and hash-seeded action proposals with `top_k` clamping and stub-identifying rationales.
> 
> Introduces a comprehensive test suite validating Protocol-shaped conformance, determinism across calls/instances, `[0,1]` bounds, `top_k` behavior, allowed proposal fields, and the **non-authoritative** invariant on all emitted models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3093f5add2dbb2040980412f6f0f3f1fa3c852c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->