### PR TITLE
feat(totali): v1 topo→defensible-DXF vertical (U1–U6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 
+# U6: CI on every push / PR (was workflow_dispatch-only). The root pytest suite
+# is fully mocked (conftest stubs laspy/pyproj/onnxruntime/ezdxf), so CI needs no
+# real LAS/ONNX/native libs and stays fast + deterministic.
 on:
-  # push:
-  #   branches: ["main"]
-  # pull_request:
-  #   branches: ["main"]
+  push:
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -22,8 +23,15 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-          pip install pytest
+          # `.[test]` = core deps + the pure-Python test extras (pytest, ezdxf,
+          # flask). It deliberately omits heavyweight/native optional packages
+          # (pdal has no pip wheel; open3d/onnxruntime are unneeded) — the suite
+          # is fully mocked via conftest stubs.
+          pip install -e .[test]
+          pip install ruff
+
+      - name: Lint (ruff)
+        run: ruff check totali/ tests/
 
       - name: Run tests
         run: python -m pytest tests/ -v --tb=short

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -20,6 +20,17 @@ geodetic:
   reject_on_mixed_datum: true
   reject_on_missing_crs: true
   elevation_unit: "US_survey_foot"
+  # U2: CRS inference + quarantine. When enabled, a missing/undeclared CRS is
+  # inferred from coordinate bounds against `jurisdiction_zones`; ambiguity routes
+  # to the quarantine UI, out-of-jurisdiction rejects. Default OFF: legacy
+  # ingestion behavior is unchanged until the partner zone envelope is provided.
+  crs_inference_enabled: false
+  # TODO(partner-data): populate with the design partner's single State Plane
+  # zone and its projected XY applicability envelope, then set
+  # crs_inference_enabled: true. Each entry:
+  #   { epsg: <allowed EPSG>, name: <zone>, xy_min: [E, N], xy_max: [E, N] }
+  # Envelopes are jurisdiction data we don't have yet — do NOT invent values.
+  jurisdiction_zones: []
 
 # Phase 2: ML Segmentation
 segmentation:
@@ -108,6 +119,8 @@ audit:
     - "ingest"
     - "transform"
     - "crs_inferred"
+    - "crs_quarantined"          # U2: ambiguous CRS routed to quarantine
+    - "crs_out_of_jurisdiction"  # U2: bounds outside every configured zone
     - "unit_validated"
     - "unit_rejected"
     # Phase 2 (segmentation)

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -142,6 +142,7 @@ audit:
     # Pipeline / orchestrator
     - "pipeline_start"
     - "pipeline_complete"
+    - "metrics_recorded"  # U5: per-phase + total timing artifact for the pilot baseline
     - "pipeline_error"
     - "phase_start"
     - "phase_complete"

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,11 @@ setup(
     extras_require={
         "ml": ["onnxruntime>=1.14.0", "open3d>=0.17.0"],
         "cad": ["ezdxf>=0.18.0"],
+        # U6: minimal deps for a green, fully-mocked CI run. Pure-Python only —
+        # no native libs (no pdal/open3d/onnxruntime). ezdxf + flask are needed
+        # by the CAD-adapter and quarantine-UI tests; the rest of the suite runs
+        # against conftest stubs.
+        "test": ["pytest>=9.0.2", "ezdxf>=0.18.0", "flask>=3.0.0"],
         "full": [
             "onnxruntime>=1.14.0",
             "open3d>=0.17.0",

--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -1,0 +1,145 @@
+"""U3 (scaffold): board/ALTA-aligned PLS certification record + gate + verify.
+
+Exercises the certification *mechanism*: a record that references the full
+defensibility chain (raw hash -> classified -> extracted -> lint decisions ->
+certifier identity/seal + board/ALTA fields), the DRAFT-until-certified gate, and
+completeness + tamper verification.
+
+ADVISOR-DEPENDENT (OQ2/KTD4): the concrete required board/ALTA field *set* is
+unknown and must be confirmed with the design-partner PLS advisor. The shipped
+default (`REQUIRED_BOARD_ALTA_FIELDS`) is an empty TODO; these tests supply a
+generic placeholder required set to exercise the contract without inventing real
+board/ALTA field names.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from totali.audit.verify import verify_certification
+from totali.linting.certification import (
+    REQUIRED_BOARD_ALTA_FIELDS,
+    CertificationBlocked,
+    CertifierIdentity,
+    CertificationRecord,
+    certify,
+    export_blocked,
+)
+from totali.pipeline.models import GeometryStatus, LintItem
+
+
+def _item(item_id, status):
+    return LintItem(item_id=item_id, geometry_type="breakline", layer="TOTaLi-SURV-BRKLN-DRAFT", status=status)
+
+
+def _certifier():
+    return CertifierIdentity(
+        name="Jane Roe", license_number="PLS-0000", jurisdiction="Example State Board",
+        seal_ref="seal://example",
+    )
+
+
+# Generic placeholder required fields — NOT real board/ALTA names (advisor TODO).
+_REQ = ("required_field_x", "required_field_y")
+_FIELDS = {"required_field_x": "value-x", "required_field_y": "value-y"}
+
+
+def _certify(lint_items, board_alta_fields=None, defer_reason=None, audit=None):
+    return certify(
+        project_id="proj-1",
+        certifier=_certifier(),
+        raw_hash="a" * 64,
+        classified_ref="classify-ref",
+        extracted_ref="extract-ref",
+        lint_items=lint_items,
+        board_alta_fields=board_alta_fields if board_alta_fields is not None else dict(_FIELDS),
+        defer_reason=defer_reason,
+        audit=audit,
+    )
+
+
+class TestAdvisorTodo:
+    def test_required_fields_default_is_empty_placeholder(self):
+        # Hard constraint: do not ship invented board/ALTA field names.
+        assert REQUIRED_BOARD_ALTA_FIELDS == ()
+
+
+class TestDraftGate:
+    def test_open_items_block_certification(self):
+        items = [_item("e1", GeometryStatus.ACCEPTED), _item("e2", GeometryStatus.DRAFT)]
+        with pytest.raises(CertificationBlocked):
+            _certify(items)
+
+    def test_open_items_allowed_when_deferred_with_reason(self):
+        items = [_item("e1", GeometryStatus.ACCEPTED), _item("e2", GeometryStatus.DRAFT)]
+        record = _certify(items, defer_reason="field verification scheduled 2026-07-01")
+        assert record.status == GeometryStatus.CERTIFIED.value
+        assert record.defer_reason
+
+    def test_all_resolved_certifies(self):
+        items = [_item("e1", GeometryStatus.ACCEPTED), _item("e2", GeometryStatus.REJECTED)]
+        record = _certify(items)
+        assert isinstance(record, CertificationRecord)
+        assert record.status == GeometryStatus.CERTIFIED.value
+        # References the full chain.
+        assert record.raw_hash == "a" * 64
+        assert record.classified_ref == "classify-ref"
+        assert record.extracted_ref == "extract-ref"
+        assert record.lint_decision_refs == ["e1:ACCEPTED", "e2:REJECTED"]
+
+
+class TestRequiredFieldsCompleteness:
+    def test_record_with_all_required_fields_verifies(self):
+        record = _certify([_item("e1", GeometryStatus.ACCEPTED)])
+        ok, errors = verify_certification(record, required_fields=_REQ)
+        assert ok is True, errors
+
+    def test_missing_required_field_fails_verification(self):
+        record = _certify(
+            [_item("e1", GeometryStatus.ACCEPTED)],
+            board_alta_fields={"required_field_x": "value-x"},  # missing _y
+        )
+        ok, errors = verify_certification(record, required_fields=_REQ)
+        assert ok is False
+        assert any("required_field_y" in e for e in errors)
+
+
+class TestChainAndTamperVerification:
+    def test_incomplete_chain_detected(self):
+        record = _certify([_item("e1", GeometryStatus.ACCEPTED)])
+        record.extracted_ref = ""  # break a chain link
+        ok, errors = verify_certification(record, required_fields=_REQ)
+        assert ok is False
+        assert any("extracted_ref" in e for e in errors)
+
+    def test_tampered_record_hash_detected(self):
+        record = _certify([_item("e1", GeometryStatus.ACCEPTED)])
+        good = record.record_hash()
+        record.board_alta_fields["required_field_x"] = "TAMPERED"
+        ok, errors = verify_certification(record, required_fields=_REQ, expected_record_hash=good)
+        assert ok is False
+        assert any("tamper" in e.lower() or "hash" in e.lower() for e in errors)
+
+    def test_incomplete_certifier_detected(self):
+        record = _certify([_item("e1", GeometryStatus.ACCEPTED)])
+        record.certifier.license_number = ""
+        ok, errors = verify_certification(record, required_fields=_REQ)
+        assert ok is False
+        assert any("license" in e.lower() or "certifier" in e.lower() for e in errors)
+
+
+class TestExportGate:
+    def test_draft_blocks_export(self):
+        assert export_blocked([_item("e1", GeometryStatus.DRAFT)]) is True
+
+    def test_all_resolved_does_not_block_export(self):
+        items = [_item("e1", GeometryStatus.ACCEPTED), _item("e2", GeometryStatus.REJECTED)]
+        assert export_blocked(items) is False
+
+
+class TestAuditEmission:
+    def test_certify_emits_audit_event(self, audit_logger):
+        _certify([_item("e1", GeometryStatus.ACCEPTED)], audit=audit_logger)
+        events = audit_logger.get_events("certify")
+        assert len(events) == 1
+        assert events[0]["data"]["pls_license"] == "PLS-0000"

--- a/tests/test_classifier_loader.py
+++ b/tests/test_classifier_loader.py
@@ -1,0 +1,88 @@
+"""U1: classifier wired to the deterministic sha256/manifest model loader.
+
+The HITL classifier loads a real ONNX model through the existing
+``totali.models.loader.load_onnx`` contract (M-1/M-2) instead of an ad-hoc
+``InferenceSession``. Benign absence (no model / no onnxruntime) falls back to
+the deterministic rule-based path; a hash or manifest MISMATCH is NOT benign and
+must fail loudly rather than silently classify with a tampered/wrong model.
+
+The model-choice itself (adapt pretrained vs train custom, KTD3) is the
+data-dependent research spike and is intentionally out of scope — this pins the
+loading *contract*, which is fully implementable now.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from totali.models.loader import ModelHashMismatch
+from totali.pipeline.models import ClassificationResult
+from totali.segmentation.classifier import PointCloudClassifier
+
+
+def _mk(audit, **cfg):
+    base = {
+        "device": "cpu",
+        "confidence_threshold": 0.75,
+        "occlusion_threshold": 0.30,
+        "batch_size": 256,
+        "voxel_size": 0.05,
+        "classes": {0: "unclassified", 2: "ground", 6: "building"},
+    }
+    base.update(cfg)
+    return PointCloudClassifier(base, audit)
+
+
+class TestBenignFallback:
+    def test_missing_model_falls_back(self, audit_logger):
+        cls = _mk(audit_logger, model_path="models/does_not_exist.onnx")
+        assert cls._load_model() is False
+        warnings = [e for e in audit_logger.get_events("classify") if "warning" in e["data"]]
+        assert warnings, "missing model must log a fallback warning, not crash"
+
+    def test_present_model_without_runtime_falls_back(self, audit_logger, tmp_path):
+        # onnxruntime is stubbed in the test env (no InferenceSession) -> the
+        # loader raises ImportError -> classifier falls back gracefully.
+        model = tmp_path / "model.onnx"
+        model.write_bytes(b"not a real onnx but the hash check passes")
+        cls = _mk(audit_logger, model_path=str(model), manifest={})
+        assert cls._load_model() is False
+
+
+class TestLoudFailureOnHashMismatch:
+    def test_hash_mismatch_raises_not_silent_fallback(self, audit_logger, tmp_path):
+        model = tmp_path / "model.onnx"
+        model.write_bytes(b"tampered weights")
+        wrong_sha = "0" * 64  # deliberately not the file's hash
+        cls = _mk(audit_logger, model_path=str(model), expected_sha256=wrong_sha, manifest={})
+        with pytest.raises(ModelHashMismatch):
+            cls._load_model()
+
+    def test_matching_hash_does_not_raise_hash_error(self, audit_logger, tmp_path):
+        model = tmp_path / "model.onnx"
+        payload = b"some bytes"
+        model.write_bytes(payload)
+        good_sha = hashlib.sha256(payload).hexdigest()
+        cls = _mk(audit_logger, model_path=str(model), expected_sha256=good_sha, manifest={})
+        # Hash passes; runtime is stubbed -> ImportError -> benign fallback (False),
+        # never a ModelHashMismatch.
+        assert cls._load_model() is False
+
+
+class TestAdvisoryFlag:
+    def test_run_output_is_non_authoritative(self, audit_logger, sample_points, sample_las, tmp_output):
+        from totali.pipeline.context import PipelineContext
+        from totali.pipeline.models import CRSMetadata, PointCloudStats
+
+        cls = _mk(audit_logger, model_path="models/absent.onnx")
+        ctx = PipelineContext(
+            input_path="/f.las", output_dir=tmp_output,
+            points_xyz=sample_points, las=sample_las,
+            crs=CRSMetadata(epsg_code=2231, is_valid=True),
+            stats=PointCloudStats(point_count=len(sample_points)), input_hash="abc",
+        )
+        result = cls.run(ctx)
+        cls_out: ClassificationResult = result.data["classification"]
+        assert cls_out.authoritative is False

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -1,0 +1,102 @@
+"""U1: surveyor correction capture (HITL training-data flywheel).
+
+A `CorrectionStore` records surveyor corrections of the classifier's *advisory*
+labels as JSONL deltas keyed to the audit record ID. It is a pure sink: it
+accumulates labeled training data and NEVER mutates authoritative geometry or
+the classifier output. The model-selection / training half of U1 (adapt vs
+train) is the data-dependent research spike and is intentionally out of scope
+here — this exercises the capture contract, which is fully implementable now.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from totali.pipeline.models import ClassificationResult
+from totali.segmentation.corrections import Correction, CorrectionStore
+
+
+class TestRecordCorrection:
+    def test_record_writes_labeled_record_linked_to_audit_id(self, tmp_path):
+        store = CorrectionStore(tmp_path)
+        c = store.record(
+            audit_id="run-abc123",
+            point_index=42,
+            original_label=5,
+            corrected_label=2,
+            surveyor="alice",
+            notes="misclassified ground as high veg",
+        )
+        assert isinstance(c, Correction)
+        assert c.audit_id == "run-abc123"
+        assert c.original_label == 5
+        assert c.corrected_label == 2
+        assert c.surveyor == "alice"
+        assert c.timestamp  # populated
+
+        # Persisted as one JSONL line keyed to the audit id.
+        lines = (tmp_path / "corrections.jsonl").read_text().splitlines()
+        assert len(lines) == 1
+        rec = json.loads(lines[0])
+        assert rec["audit_id"] == "run-abc123"
+        assert rec["point_index"] == 42
+        assert rec["corrected_label"] == 2
+
+    def test_records_accumulate_as_training_data(self, tmp_path):
+        store = CorrectionStore(tmp_path)
+        store.record("run-1", 1, 5, 2, "alice")
+        store.record("run-1", 2, 4, 6, "alice")
+        store.record("run-2", 3, 0, 2, "bob")
+        assert len(store.all_corrections()) == 3
+        assert len(store.corrections_for("run-1")) == 2
+        assert len(store.corrections_for("run-2")) == 1
+
+    def test_export_training_data_shape(self, tmp_path):
+        store = CorrectionStore(tmp_path)
+        store.record("run-1", 7, 5, 2, "alice")
+        data = store.export_training_data()
+        assert data == [
+            {
+                "audit_id": "run-1",
+                "point_index": 7,
+                "label": 2,
+                "original_label": 5,
+                "surveyor": "alice",
+            }
+        ]
+
+    def test_persists_across_store_instances(self, tmp_path):
+        CorrectionStore(tmp_path).record("run-1", 1, 5, 2, "alice")
+        # A fresh store over the same dir reads back the accumulated flywheel.
+        assert len(CorrectionStore(tmp_path).all_corrections() ) == 1
+
+
+class TestGeometryUntouched:
+    def test_recording_does_not_mutate_classifier_output(self, tmp_path):
+        labels = np.array([5, 5, 5, 5], dtype=np.int32)
+        confidences = np.array([0.4, 0.4, 0.4, 0.4], dtype=np.float32)
+        result = ClassificationResult(labels=labels.copy(), confidences=confidences.copy())
+
+        store = CorrectionStore(tmp_path)
+        store.record("run-1", 0, original_label=int(result.labels[0]), corrected_label=2, surveyor="alice")
+
+        # The advisory classifier output is authoritative-geometry-adjacent and
+        # must be left byte-identical: corrections live in their own sink.
+        assert np.array_equal(result.labels, labels)
+        assert result.authoritative is False
+
+
+class TestRecordBatch:
+    def test_record_batch_writes_all(self, tmp_path):
+        store = CorrectionStore(tmp_path)
+        out = store.record_batch(
+            audit_id="run-1",
+            point_indices=[1, 2, 3],
+            original_labels=[5, 4, 0],
+            corrected_labels=[2, 6, 2],
+            surveyor="alice",
+        )
+        assert len(out) == 3
+        assert len(store.corrections_for("run-1")) == 3

--- a/tests/test_crs_inference.py
+++ b/tests/test_crs_inference.py
@@ -1,0 +1,193 @@
+"""U2: CRS inference + jurisdiction routing — pure module tests.
+
+`crs_inference` is deliberately dependency-light: given a (possibly absent)
+declared EPSG and the data's projected XY bounds, it decides whether the CRS is
+DECLARED, INFERRED (single zone match, flagged for review), AMBIGUOUS (>1 zone
+-> quarantine), OUT_OF_JURISDICTION (no zone -> reject), or MISSING (no signal).
+
+No network, no pyproj, no fabricated coordinates: jurisdiction zones are passed
+in explicitly by the caller (built from config). Tests inject synthetic zones so
+the suite stays fully mocked and deterministic.
+"""
+
+from totali.geodetic.crs_inference import (
+    CRSInferenceStatus,
+    JurisdictionZone,
+    build_jurisdiction,
+    infer_crs,
+)
+
+
+# A jurisdiction whose single zone comfortably contains the synthetic fake-LAS
+# bounds (x,y in [0, 1000]); far enough margin that exact RNG bounds don't matter.
+_ZONE_NORTH = JurisdictionZone(
+    epsg=2231, name="NAD83 Colorado North (ftUS)", xy_min=(-1.0, -1.0), xy_max=(2000.0, 2000.0)
+)
+# A second zone overlapping the same envelope -> used to force AMBIGUOUS.
+_ZONE_CENTRAL = JurisdictionZone(
+    epsg=2232, name="NAD83 Colorado Central (ftUS)", xy_min=(-1.0, -1.0), xy_max=(2000.0, 2000.0)
+)
+# A disjoint zone, far away -> used to force OUT_OF_JURISDICTION.
+_ZONE_FAR = JurisdictionZone(
+    epsg=2233, name="NAD83 Colorado South (ftUS)", xy_min=(1.0e6, 1.0e6), xy_max=(2.0e6, 2.0e6)
+)
+
+_BOUNDS_MIN = (0.0, 0.0, 100.0)
+_BOUNDS_MAX = (1000.0, 1000.0, 200.0)
+
+
+class TestJurisdictionZone:
+    def test_contains_inside(self):
+        assert _ZONE_NORTH.contains(500.0, 500.0) is True
+
+    def test_contains_on_edge(self):
+        assert _ZONE_NORTH.contains(-1.0, 2000.0) is True
+
+    def test_contains_outside(self):
+        assert _ZONE_NORTH.contains(3000.0, 3000.0) is False
+
+
+class TestBuildJurisdiction:
+    def test_empty_when_unconfigured(self):
+        assert build_jurisdiction({}) == []
+
+    def test_builds_zones_from_config(self):
+        cfg = {
+            "jurisdiction_zones": [
+                {
+                    "epsg": 2231,
+                    "name": "North",
+                    "xy_min": [0.0, 0.0],
+                    "xy_max": [1000.0, 1000.0],
+                }
+            ]
+        }
+        zones = build_jurisdiction(cfg)
+        assert len(zones) == 1
+        assert zones[0].epsg == 2231
+        assert zones[0].name == "North"
+        assert zones[0].xy_min == (0.0, 0.0)
+        assert zones[0].xy_max == (1000.0, 1000.0)
+
+
+class TestDeclared:
+    def test_declared_in_allowlist_is_honored(self):
+        result = infer_crs(
+            declared_epsg=2231,
+            bounds_min=_BOUNDS_MIN,
+            bounds_max=_BOUNDS_MAX,
+            jurisdiction=[_ZONE_NORTH],
+            allowed_epsg=[2231, 2232],
+        )
+        assert result.status is CRSInferenceStatus.DECLARED
+        assert result.is_declared is True
+        assert result.inferred_epsg == 2231
+        assert result.requires_quarantine is False
+        assert result.is_rejected is False
+
+    def test_declared_out_of_allowlist_is_rejected(self):
+        result = infer_crs(
+            declared_epsg=9999,
+            bounds_min=_BOUNDS_MIN,
+            bounds_max=_BOUNDS_MAX,
+            jurisdiction=[_ZONE_NORTH],
+            allowed_epsg=[2231, 2232],
+        )
+        assert result.status is CRSInferenceStatus.OUT_OF_JURISDICTION
+        assert result.is_rejected is True
+        assert "9999" in result.reason
+
+
+class TestInferred:
+    def test_single_zone_match_is_inferred_and_flagged(self):
+        result = infer_crs(
+            declared_epsg=None,
+            bounds_min=_BOUNDS_MIN,
+            bounds_max=_BOUNDS_MAX,
+            jurisdiction=[_ZONE_NORTH, _ZONE_FAR],
+            allowed_epsg=[2231, 2232, 2233],
+        )
+        assert result.status is CRSInferenceStatus.INFERRED
+        assert result.inferred_epsg == 2231
+        assert result.requires_review is True
+        assert len(result.candidates) == 1
+        assert 0.0 < result.candidates[0].confidence <= 1.0
+
+    def test_inferred_confidence_higher_when_fully_contained(self):
+        # Bounds fully inside -> higher confidence than centroid-only containment.
+        fully = infer_crs(
+            declared_epsg=None,
+            bounds_min=_BOUNDS_MIN,
+            bounds_max=_BOUNDS_MAX,
+            jurisdiction=[_ZONE_NORTH],
+            allowed_epsg=[2231],
+        )
+        partial_zone = JurisdictionZone(
+            epsg=2231, name="tight", xy_min=(400.0, 400.0), xy_max=(2000.0, 2000.0)
+        )
+        partial = infer_crs(
+            declared_epsg=None,
+            bounds_min=_BOUNDS_MIN,
+            bounds_max=_BOUNDS_MAX,
+            jurisdiction=[partial_zone],
+            allowed_epsg=[2231],
+        )
+        assert fully.candidates[0].confidence > partial.candidates[0].confidence
+
+
+class TestAmbiguous:
+    def test_two_matching_zones_route_to_quarantine(self):
+        result = infer_crs(
+            declared_epsg=None,
+            bounds_min=_BOUNDS_MIN,
+            bounds_max=_BOUNDS_MAX,
+            jurisdiction=[_ZONE_NORTH, _ZONE_CENTRAL],
+            allowed_epsg=[2231, 2232],
+        )
+        assert result.status is CRSInferenceStatus.AMBIGUOUS
+        assert result.requires_quarantine is True
+        assert len(result.candidates) == 2
+        epsgs = {c.epsg for c in result.candidates}
+        assert epsgs == {2231, 2232}
+
+
+class TestOutOfJurisdiction:
+    def test_bounds_outside_all_zones_rejected(self):
+        result = infer_crs(
+            declared_epsg=None,
+            bounds_min=_BOUNDS_MIN,
+            bounds_max=_BOUNDS_MAX,
+            jurisdiction=[_ZONE_FAR],
+            allowed_epsg=[2233],
+        )
+        assert result.status is CRSInferenceStatus.OUT_OF_JURISDICTION
+        assert result.is_rejected is True
+        assert result.requires_quarantine is False
+
+
+class TestMissing:
+    def test_no_declared_no_bounds_is_missing(self):
+        result = infer_crs(
+            declared_epsg=None,
+            bounds_min=None,
+            bounds_max=None,
+            jurisdiction=[_ZONE_NORTH],
+            allowed_epsg=[2231],
+        )
+        assert result.status is CRSInferenceStatus.MISSING
+        # No coordinates to infer from -> operator must resolve; surface all
+        # configured zones as candidates for the quarantine UI.
+        assert result.requires_quarantine is True
+        assert {c.epsg for c in result.candidates} == {2231}
+
+    def test_no_declared_no_jurisdiction_is_missing_without_candidates(self):
+        result = infer_crs(
+            declared_epsg=None,
+            bounds_min=None,
+            bounds_max=None,
+            jurisdiction=[],
+            allowed_epsg=[2231],
+        )
+        assert result.status is CRSInferenceStatus.MISSING
+        assert result.candidates == []
+        assert result.requires_quarantine is False

--- a/tests/test_e2e_topo_real.py
+++ b/tests/test_e2e_topo_real.py
@@ -1,0 +1,99 @@
+"""U4 (scaffold): end-to-end topo → defensible DXF on real partner data.
+
+The full real-LAS run with geodetic gates ACTIVE (not the stub-relaxed E2E in
+``test_pipeline_e2e.py``) is the one piece of this plan that genuinely needs a
+dataset we do not have. So this file is split:
+
+- ``TestRealPartnerLasE2E`` — the real run. SKIPPED unless ``TOTALI_PARTNER_LAS``
+  points at a real partner LAS sample. Its body is the executable *contract* for
+  when that dataset lands: full PHASE_ORDER, gates active, stampable DXF carrying
+  an audit reference, audit chain verifies end-to-end. **TODO(partner-data):**
+  obtain the partner LAS sample + agreed DXF deliverable spec, then this runs.
+- ``TestDwgLoudStub`` — runs always (no data needed): a DWG export request must
+  fail loudly (KTD2). This is the U4 "DWG export request fails loudly" scenario.
+
+Nothing here fabricates partner data: the real test is inert until a real file
+is provided out-of-band via the environment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from totali.audit.logger import AuditLogger
+from totali.audit.verify import verify_log
+from totali.cad_shielding.shield import CADShield, UnsupportedCADFormat
+from totali.pipeline.orchestrator import PHASE_ORDER, PipelineOrchestrator
+
+_PARTNER_LAS = os.environ.get("TOTALI_PARTNER_LAS")
+
+
+@pytest.mark.skipif(
+    not _PARTNER_LAS,
+    reason=(
+        "U4 real-LAS E2E needs a partner dataset (set TOTALI_PARTNER_LAS to a real "
+        "topo LAS). TODO(partner-data): wire the agreed DXF deliverable spec + zone "
+        "envelope and run with geodetic gates active."
+    ),
+)
+class TestRealPartnerLasE2E:
+    """Contract for the un-relaxed, real-data run. Inert until the dataset lands."""
+
+    def _gated_config(self, sample_config: dict) -> dict:
+        cfg = dict(sample_config)
+        cfg["geodetic"] = dict(sample_config["geodetic"])
+        # Gates ACTIVE — the whole point vs. the stub-relaxed E2E. The partner's
+        # real LAS must declare (or allow inference of) a CRS in the allowlist.
+        cfg["geodetic"]["reject_on_missing_crs"] = True
+        cfg["geodetic"]["reject_on_mixed_datum"] = True
+        # TODO(partner-data): populate jurisdiction_zones with the partner zone
+        # envelope and set crs_inference_enabled if the LAS lacks a CRS VLR.
+        return cfg
+
+    def test_real_las_flows_all_phases_to_stampable_dxf(self, sample_config, tmp_path):
+        cfg = self._gated_config(sample_config)
+        out = tmp_path / "out"
+        out.mkdir()
+        audit = AuditLogger(log_dir=str(tmp_path / "audit"), project_id="u4_real")
+        orch = PipelineOrchestrator(cfg, audit, out)
+
+        result = orch.run(_PARTNER_LAS, phase="all")
+
+        # All five phases ran with gates active.
+        assert [p.phase for p in result.phases] == PHASE_ORDER
+        assert result.success is True, [
+            (p.phase, p.success, p.message) for p in result.phases
+        ]
+
+        # A DXF was produced and carries an audit reference.
+        dxf = out / "totali_draft_output.dxf"
+        assert dxf.exists()
+        manifest = json.loads((out / "entity_manifest.json").read_text())
+        assert manifest["audit_reference"]["input_hash"]
+
+        # The audit chain verifies end-to-end (SC1).
+        ok, errors = verify_log(audit.log_path)
+        assert ok is True, errors
+
+
+class TestDwgLoudStub:
+    """KTD2: DWG export must fail loudly — no silent half-support. Runs always."""
+
+    def _cfg(self, fmt: str) -> dict:
+        return {
+            "format": fmt,
+            "geometry_healing": {"close_tolerance": 0.001},
+            "layer_mapping": {"ground_surface": "TOTaLi-SURV-DTM-DRAFT"},
+        }
+
+    def test_dwg_request_fails_loudly(self, audit_logger):
+        with pytest.raises(UnsupportedCADFormat) as exc:
+            CADShield(self._cfg("dwg"), audit_logger)
+        assert "dwg" in str(exc.value).lower()
+
+    def test_dxf_is_accepted(self, audit_logger):
+        shield = CADShield(self._cfg("dxf"), audit_logger)
+        assert shield.format == "dxf"

--- a/tests/test_geodetic_quarantine.py
+++ b/tests/test_geodetic_quarantine.py
@@ -1,0 +1,171 @@
+"""U2: GeodeticGatekeeper CRS-inference + quarantine routing (integration).
+
+Exercises the gatekeeper's `run()` wiring on top of the pure `crs_inference`
+module: a missing-CRS LAS is inferred from coordinate bounds against the
+configured jurisdiction, with ambiguity routed to quarantine and
+out-of-jurisdiction data rejected — all flask-free (the in-memory UI queue is a
+best-effort side channel, the JSON artifact + audit event are authoritative).
+
+Inference defaults OFF so every pre-existing gatekeeper test is untouched.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from totali.geodetic.gatekeeper import GeodeticGatekeeper
+from totali.pipeline.context import PipelineContext
+
+
+_BASE_CFG = {
+    "allowed_crs": ["EPSG:2231", "EPSG:2232", "EPSG:2233"],
+    "reject_on_missing_crs": True,
+    "geoid_model": "GEOID18",
+    "elevation_unit": "US_survey_foot",
+}
+
+# Synthetic zones. The fake LAS has x,y in [0, 1000]; a wide envelope contains it.
+_ZONE_WIDE_2231 = {
+    "epsg": 2231,
+    "name": "NAD83 Colorado North (ftUS)",
+    "xy_min": [-1.0, -1.0],
+    "xy_max": [2000.0, 2000.0],
+}
+_ZONE_WIDE_2232 = {
+    "epsg": 2232,
+    "name": "NAD83 Colorado Central (ftUS)",
+    "xy_min": [-1.0, -1.0],
+    "xy_max": [2000.0, 2000.0],
+}
+_ZONE_FAR_2233 = {
+    "epsg": 2233,
+    "name": "NAD83 Colorado South (ftUS)",
+    "xy_min": [1.0e6, 1.0e6],
+    "xy_max": [2.0e6, 2.0e6],
+}
+
+
+def _mk_gatekeeper(audit_logger, **overrides):
+    cfg = dict(_BASE_CFG)
+    cfg.update(overrides)
+    return GeodeticGatekeeper(cfg, audit_logger)
+
+
+def _make_las(tmp_path):
+    """Create a real (content-irrelevant) LAS file so chain-of-custody hashing
+    succeeds; the stubbed laspy.read ignores the bytes."""
+    las = tmp_path / "survey.las"
+    las.write_bytes(b"\x00" * 256)
+    return las
+
+
+def _run(gk, tmp_path):
+    las = _make_las(tmp_path)
+    out = tmp_path / "out"
+    out.mkdir(exist_ok=True)
+    ctx = PipelineContext(input_path=str(las), output_dir=out)
+    return gk.run(ctx), out
+
+
+class TestInferenceDisabledPreservesBehavior:
+    def test_missing_crs_still_rejected_when_inference_off(self, audit_logger, tmp_path):
+        gk = _mk_gatekeeper(audit_logger)  # crs_inference_enabled defaults False
+        result, _ = _run(gk, tmp_path)
+        assert result.success is False
+        assert "CRS validation failed" in result.message
+
+
+class TestSingleZoneInference:
+    def test_single_zone_match_infers_and_proceeds(self, audit_logger, tmp_path):
+        gk = _mk_gatekeeper(
+            audit_logger,
+            crs_inference_enabled=True,
+            jurisdiction_zones=[_ZONE_WIDE_2231, _ZONE_FAR_2233],
+        )
+        result, _ = _run(gk, tmp_path)
+        assert result.success is True
+        assert result.data["crs"].epsg_code == 2231
+
+        inferred = audit_logger.get_events("crs_inferred")
+        assert len(inferred) == 1
+        assert inferred[0]["data"]["epsg"] == 2231
+        assert inferred[0]["data"]["requires_review"] is True
+
+
+class TestAmbiguousQuarantine:
+    def test_two_zones_route_to_quarantine(self, audit_logger, tmp_path):
+        gk = _mk_gatekeeper(
+            audit_logger,
+            crs_inference_enabled=True,
+            jurisdiction_zones=[_ZONE_WIDE_2231, _ZONE_WIDE_2232],
+        )
+        result, out = _run(gk, tmp_path)
+
+        assert result.success is False
+        assert result.data.get("quarantined") is True
+
+        artifact = out / "survey_crs_quarantine.json"
+        assert artifact.exists()
+        payload = json.loads(artifact.read_text())
+        assert {c["epsg"] for c in payload["candidates"]} == {2231, 2232}
+        assert payload["status"] == "ambiguous"
+
+        events = audit_logger.get_events("crs_quarantined")
+        assert len(events) == 1
+        assert events[0]["data"]["item_id"] == "survey"
+
+
+class TestOutOfJurisdiction:
+    def test_bounds_outside_zones_rejected(self, audit_logger, tmp_path):
+        gk = _mk_gatekeeper(
+            audit_logger,
+            crs_inference_enabled=True,
+            jurisdiction_zones=[_ZONE_FAR_2233],
+        )
+        result, _ = _run(gk, tmp_path)
+        assert result.success is False
+        assert result.data.get("rejected") is True
+        assert len(audit_logger.get_events("crs_out_of_jurisdiction")) == 1
+
+
+class TestOperatorResolutionHonored:
+    def test_existing_confirm_resolution_is_honored(self, audit_logger, tmp_path):
+        # Operator already resolved this item via the quarantine UI; the gatekeeper
+        # must honor the written resolution on the next run instead of re-inferring.
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "survey_crs_resolution.json").write_text(
+            json.dumps(
+                {"item_id": "survey", "action": "confirm", "epsg": 2232, "operator": "alice"}
+            )
+        )
+        gk = _mk_gatekeeper(
+            audit_logger,
+            crs_inference_enabled=True,
+            jurisdiction_zones=[_ZONE_WIDE_2231, _ZONE_WIDE_2232],  # would be ambiguous
+        )
+        ctx = PipelineContext(input_path=str(_make_las(tmp_path)), output_dir=out)
+        result = gk.run(ctx)
+        assert result.success is True
+        assert result.data["crs"].epsg_code == 2232
+
+
+class TestQuarantineQueueWiring:
+    def test_ambiguous_enqueues_when_ui_available(self, audit_logger, tmp_path):
+        pytest.importorskip("flask")
+        from totali.quarantine_ui.app import QUARANTINE_QUEUE
+
+        QUARANTINE_QUEUE.clear()
+        try:
+            gk = _mk_gatekeeper(
+                audit_logger,
+                crs_inference_enabled=True,
+                jurisdiction_zones=[_ZONE_WIDE_2231, _ZONE_WIDE_2232],
+            )
+            _run(gk, tmp_path)
+            assert "survey" in QUARANTINE_QUEUE
+            assert {c["epsg"] for c in QUARANTINE_QUEUE["survey"]["candidates"]} == {2231, 2232}
+        finally:
+            QUARANTINE_QUEUE.clear()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,116 @@
+"""U5: pipeline timing instrumentation (pilot baseline for SC2 / R7).
+
+Aggregates per-phase + total wall-clock timing into a metrics artifact written
+alongside the audit record, with an optional operator-supplied manual baseline.
+
+SC2 guard: NO time-savings percentage is computed or emitted anywhere. The
+baseline is *measured* during the pilot; the public claim is set
+post-measurement (KTD5). These tests pin that raw-seconds-only contract.
+"""
+
+from __future__ import annotations
+
+import json
+
+from totali.pipeline.metrics import PhaseTiming, RunMetrics
+from totali.pipeline.models import PhaseResult, PipelineResult
+
+
+def _sample_result():
+    return PipelineResult(
+        project_id="proj-1",
+        duration_sec=1.5,
+        phases=[
+            PhaseResult(phase="geodetic", success=True, duration_sec=0.4),
+            PhaseResult(phase="segment", success=True, duration_sec=0.6),
+            PhaseResult(phase="extract", success=False, duration_sec=0.5),
+        ],
+    )
+
+
+class TestFromPipelineResult:
+    def test_captures_total_and_per_phase(self):
+        metrics = RunMetrics.from_pipeline_result(_sample_result())
+        assert metrics.project_id == "proj-1"
+        assert metrics.total_duration_sec == 1.5
+        assert len(metrics.phases) == 3
+        assert all(isinstance(p, PhaseTiming) for p in metrics.phases)
+        assert metrics.phases[0].phase == "geodetic"
+        assert metrics.phases[0].duration_sec == 0.4
+        assert metrics.phases[2].success is False
+
+
+class TestManualBaseline:
+    def test_absent_by_default(self):
+        d = RunMetrics.from_pipeline_result(_sample_result()).to_dict()
+        assert "manual_baseline_sec" not in d
+
+    def test_present_when_provided(self):
+        d = RunMetrics.from_pipeline_result(
+            _sample_result(), manual_baseline_sec=3600.0
+        ).to_dict()
+        assert d["manual_baseline_sec"] == 3600.0
+
+
+class TestNoPercentClaim:
+    def test_output_contains_no_savings_percentage(self):
+        # With a manual baseline present (the tempting moment to compute a %),
+        # the serialized output must still carry NO percentage / savings claim.
+        metrics = RunMetrics.from_pipeline_result(
+            _sample_result(), manual_baseline_sec=3600.0
+        )
+        blob = json.dumps(metrics.to_dict()).lower()
+        for forbidden in ("percent", "%", "saving", "reduction", "faster", "speedup"):
+            assert forbidden not in blob, f"SC2 guard: {forbidden!r} must not appear"
+
+
+class TestArtifactWrite:
+    def test_writes_alongside_audit_record_and_emits_event(self, audit_logger):
+        metrics = RunMetrics.from_pipeline_result(_sample_result())
+        artifact = metrics.write(audit_logger)
+
+        # Alongside the audit record (same directory as the audit log file).
+        assert artifact.exists()
+        assert artifact.parent == audit_logger.log_path.parent
+
+        data = json.loads(artifact.read_text())
+        assert data["total_duration_sec"] == 1.5
+        assert [p["phase"] for p in data["phases"]] == ["geodetic", "segment", "extract"]
+
+        events = audit_logger.get_events("metrics_recorded")
+        assert len(events) == 1
+        assert events[0]["data"]["total_duration_sec"] == 1.5
+
+
+class TestOrchestratorIntegration:
+    def test_run_records_metrics_artifact(self, audit_logger, sample_config, tmp_path):
+        from totali.pipeline.orchestrator import PipelineOrchestrator
+
+        out = tmp_path / "out"
+        out.mkdir()
+        las = tmp_path / "input.las"
+        las.write_bytes(b"\x00" * 100)
+
+        orch = PipelineOrchestrator(sample_config, audit_logger, out)
+        orch.run(str(las), phase="geodetic")
+
+        artifact = audit_logger.log_path.with_suffix(".metrics.json")
+        assert artifact.exists(), "orchestrator run must emit a timing metrics artifact"
+        data = json.loads(artifact.read_text())
+        assert "total_duration_sec" in data
+        assert len(data["phases"]) >= 1
+        assert len(audit_logger.get_events("metrics_recorded")) == 1
+
+    def test_run_records_manual_baseline_when_passed(self, audit_logger, sample_config, tmp_path):
+        from totali.pipeline.orchestrator import PipelineOrchestrator
+
+        out = tmp_path / "out"
+        out.mkdir()
+        las = tmp_path / "input.las"
+        las.write_bytes(b"\x00" * 100)
+
+        orch = PipelineOrchestrator(sample_config, audit_logger, out)
+        orch.run(str(las), phase="geodetic", manual_baseline_sec=1800.0)
+
+        data = json.loads(audit_logger.log_path.with_suffix(".metrics.json").read_text())
+        assert data["manual_baseline_sec"] == 1800.0

--- a/tests/test_shield.py
+++ b/tests/test_shield.py
@@ -188,6 +188,31 @@ class TestPhaseRun:
         assert result.success is False
 
     @patch("totali.cad_shielding.shield.CADShield._write_dxf")
+    def test_dxf_manifest_carries_audit_reference(
+        self, mock_write, shield, tmp_output, sample_extraction, sample_classification
+    ):
+        """U4: the DXF deliverable's manifest must carry a reference back to the
+        audit chain (raw input hash + audit log path) so it is verifiable."""
+        mock_write.side_effect = lambda ext, path, ctx: shield._write_dxf_manual(ext, path, ctx)
+        ctx = PipelineContext(
+            input_path="/f.las", output_dir=tmp_output,
+            extraction=sample_extraction,
+            crs=CRSMetadata(epsg_code=2231, is_valid=True),
+            stats=PointCloudStats(point_count=500),
+            classification=sample_classification,
+            input_hash="rawhash123",
+        )
+        result = shield.run(ctx)
+        manifest = result.data["manifest"]
+        assert "audit_reference" in manifest
+        assert manifest["audit_reference"]["input_hash"] == "rawhash123"
+        assert manifest["audit_reference"]["audit_log"] == str(shield.audit.log_path)
+
+        # And it is persisted in the sidecar artifact next to the DXF.
+        on_disk = json.loads((tmp_output / "entity_manifest.json").read_text())
+        assert on_disk["audit_reference"]["input_hash"] == "rawhash123"
+
+    @patch("totali.cad_shielding.shield.CADShield._write_dxf")
     def test_all_entities_are_draft(self, mock_write, shield, tmp_output, sample_extraction, sample_classification):
         mock_write.side_effect = lambda ext, path, ctx: shield._write_dxf_manual(ext, path, ctx)
         ctx = PipelineContext(

--- a/totali/audit/verify.py
+++ b/totali/audit/verify.py
@@ -14,6 +14,51 @@ import hashlib
 import json
 import sys
 from pathlib import Path
+from typing import Any, Optional, Sequence
+
+
+def verify_certification(
+    record: Any,
+    *,
+    required_fields: Sequence[str] = (),
+    expected_record_hash: Optional[str] = None,
+) -> tuple[bool, list[str]]:
+    """U3: validate a certification record's completeness and tamper-evidence.
+
+    Checks (a) the certifier identity is complete, (b) every chain link
+    (raw_hash -> classified -> extracted -> lint decisions) is present, (c) all
+    ``required_fields`` (the advisor-defined board/ALTA set) are present in the
+    record's ``board_alta_fields``, and (d) — when ``expected_record_hash`` is
+    supplied — the recomputed record hash still matches (no tampering).
+
+    Returns ``(ok, errors)``. The required-field set is caller-supplied because
+    it is advisor-defined (see ``certification.REQUIRED_BOARD_ALTA_FIELDS``).
+    """
+    errors: list[str] = []
+
+    certifier = getattr(record, "certifier", None)
+    if certifier is None or not certifier.is_complete():
+        missing = "certifier identity incomplete (name/license_number/jurisdiction required)"
+        errors.append(missing)
+
+    for link in ("raw_hash", "classified_ref", "extracted_ref"):
+        if not getattr(record, link, ""):
+            errors.append(f"chain link missing/empty: {link}")
+    if not getattr(record, "lint_decision_refs", None):
+        errors.append("chain link missing/empty: lint_decision_refs")
+
+    fields = getattr(record, "board_alta_fields", {}) or {}
+    for key in required_fields:
+        if key not in fields:
+            errors.append(f"required board/ALTA field missing: {key}")
+
+    if expected_record_hash is not None and record.record_hash() != expected_record_hash:
+        errors.append(
+            "record hash mismatch — certification record tampered or altered "
+            f"after sealing (expected {expected_record_hash[:16]}...)"
+        )
+
+    return len(errors) == 0, errors
 
 
 def verify_log(path: Path, hash_algo: str = "sha256") -> tuple[bool, list[str]]:

--- a/totali/cad_shielding/shield.py
+++ b/totali/cad_shielding/shield.py
@@ -121,6 +121,14 @@ class CADShield(PipelinePhase):
         dxf_path = output_dir / "totali_draft_output.dxf"
         entity_manifest = self._write_dxf(extraction, dxf_path, context)
 
+        # U4: the DXF deliverable must carry a reference back to the audit chain
+        # (raw input hash + audit log) so the stampable output is verifiable
+        # end-to-end against its chain of custody.
+        entity_manifest["audit_reference"] = {
+            "input_hash": context.input_hash,
+            "audit_log": str(self.audit.log_path),
+        }
+
         # Write entity manifest (chain of custody)
         manifest_path = output_dir / "entity_manifest.json"
         with open(manifest_path, "w") as f:

--- a/totali/geodetic/crs_inference.py
+++ b/totali/geodetic/crs_inference.py
@@ -1,0 +1,237 @@
+"""U2: CRS inference + jurisdiction routing.
+
+Pure, deterministic candidate generation for the geodetic gatekeeper. Given a
+(possibly absent) declared EPSG and the data's projected XY bounds, decide what
+to do with a point cloud whose CRS is not already declared-and-allowed:
+
+    DECLARED            declared EPSG is inside the jurisdiction allowlist; honor it
+    INFERRED            exactly one configured jurisdiction zone contains the data;
+                        low-trust, flagged for surveyor review
+    AMBIGUOUS           >1 zone contains the data -> route to the quarantine UI
+    OUT_OF_JURISDICTION declared-but-disallowed, or bounds outside every zone -> reject
+    MISSING             no declared CRS and nothing to infer from
+
+Design constraints (see plan U2):
+
+- **No network, no fabricated coordinates.** Jurisdiction zone envelopes are
+  supplied by the caller (built from config), never invented here. We don't have
+  the design partner's State Plane zone envelope yet, so production config leaves
+  ``jurisdiction_zones`` empty (a documented TODO); the *mechanism* is complete.
+- **No pyproj dependency in the core.** Containment is plain interval geometry on
+  projected XY, so the unit tests stay fully mocked and deterministic.
+- **Advisory, not authoritative.** An INFERRED CRS is always flagged for review;
+  the surveyor remains sovereign over the final CRS decision.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, Sequence
+
+
+class CRSInferenceStatus(str, Enum):
+    DECLARED = "declared"
+    INFERRED = "inferred"
+    AMBIGUOUS = "ambiguous"
+    OUT_OF_JURISDICTION = "out_of_jurisdiction"
+    MISSING = "missing"
+
+
+@dataclass(frozen=True)
+class JurisdictionZone:
+    """A configured State Plane zone and its projected XY applicability envelope.
+
+    ``xy_min``/``xy_max`` are ``(easting, northing)`` in the project unit. They
+    define where coordinates of this zone are expected to fall — used to infer the
+    zone from coordinate magnitude when the LAS declares no CRS.
+    """
+
+    epsg: int
+    name: str
+    xy_min: tuple[float, float]
+    xy_max: tuple[float, float]
+
+    def contains(self, x: float, y: float) -> bool:
+        return (
+            self.xy_min[0] <= x <= self.xy_max[0]
+            and self.xy_min[1] <= y <= self.xy_max[1]
+        )
+
+
+@dataclass
+class CRSCandidate:
+    epsg: int
+    name: str
+    confidence: float
+
+
+@dataclass
+class CRSInferenceResult:
+    status: CRSInferenceStatus
+    candidates: list[CRSCandidate] = field(default_factory=list)
+    declared_epsg: Optional[int] = None
+    reason: str = ""
+
+    @property
+    def is_declared(self) -> bool:
+        return self.status is CRSInferenceStatus.DECLARED
+
+    @property
+    def is_rejected(self) -> bool:
+        return self.status is CRSInferenceStatus.OUT_OF_JURISDICTION
+
+    @property
+    def requires_review(self) -> bool:
+        """An inferred CRS is never authoritative — the surveyor must confirm."""
+        return self.status is CRSInferenceStatus.INFERRED
+
+    @property
+    def requires_quarantine(self) -> bool:
+        """Ambiguity (or a missing CRS with candidates) routes to the operator."""
+        if self.status is CRSInferenceStatus.AMBIGUOUS:
+            return True
+        if self.status is CRSInferenceStatus.MISSING:
+            return bool(self.candidates)
+        return False
+
+    @property
+    def inferred_epsg(self) -> Optional[int]:
+        """The single resolved EPSG for DECLARED/INFERRED; ``None`` otherwise."""
+        if self.status in (CRSInferenceStatus.DECLARED, CRSInferenceStatus.INFERRED):
+            return self.candidates[0].epsg if self.candidates else self.declared_epsg
+        return None
+
+
+def build_jurisdiction(config: dict) -> list[JurisdictionZone]:
+    """Build the jurisdiction allowlist from a geodetic config section.
+
+    Reads ``config['jurisdiction_zones']`` — a list of
+    ``{epsg, name, xy_min, xy_max}`` dicts. Missing/empty -> ``[]`` (inference
+    has nothing to match against and will defer to the declared/reject path).
+    """
+    zones: list[JurisdictionZone] = []
+    for entry in config.get("jurisdiction_zones", []) or []:
+        zones.append(
+            JurisdictionZone(
+                epsg=int(entry["epsg"]),
+                name=str(entry.get("name", f"EPSG:{entry['epsg']}")),
+                xy_min=(float(entry["xy_min"][0]), float(entry["xy_min"][1])),
+                xy_max=(float(entry["xy_max"][0]), float(entry["xy_max"][1])),
+            )
+        )
+    return zones
+
+
+def _centroid(bounds_min: Sequence[float], bounds_max: Sequence[float]) -> tuple[float, float]:
+    return (
+        (bounds_min[0] + bounds_max[0]) / 2.0,
+        (bounds_min[1] + bounds_max[1]) / 2.0,
+    )
+
+
+def _fit_confidence(
+    zone: JurisdictionZone,
+    bounds_min: Sequence[float],
+    bounds_max: Sequence[float],
+) -> float:
+    """Deterministic, explainable confidence for a zone match.
+
+    0.9 when the full XY extent sits inside the zone envelope; 0.6 when only the
+    centroid is inside (extent spills past an edge). No magic — just "fully
+    contained" vs "partially contained". Inference is advisory regardless.
+    """
+    corners = (
+        (bounds_min[0], bounds_min[1]),
+        (bounds_min[0], bounds_max[1]),
+        (bounds_max[0], bounds_min[1]),
+        (bounds_max[0], bounds_max[1]),
+    )
+    if all(zone.contains(cx, cy) for cx, cy in corners):
+        return 0.9
+    return 0.6
+
+
+def infer_crs(
+    *,
+    declared_epsg: Optional[int],
+    bounds_min: Optional[Sequence[float]],
+    bounds_max: Optional[Sequence[float]],
+    jurisdiction: list[JurisdictionZone],
+    allowed_epsg: Sequence[int],
+) -> CRSInferenceResult:
+    """Resolve a CRS decision from declared metadata + projected bounds.
+
+    See module docstring for the status taxonomy.
+    """
+    allowed = {e for e in allowed_epsg if e is not None}
+
+    # 1. Declared CRS short-circuits inference.
+    if declared_epsg:
+        if declared_epsg in allowed:
+            zone_name = next(
+                (z.name for z in jurisdiction if z.epsg == declared_epsg),
+                f"EPSG:{declared_epsg}",
+            )
+            return CRSInferenceResult(
+                status=CRSInferenceStatus.DECLARED,
+                candidates=[CRSCandidate(declared_epsg, zone_name, 1.0)],
+                declared_epsg=declared_epsg,
+                reason="CRS declared in LAS metadata and inside jurisdiction allowlist",
+            )
+        return CRSInferenceResult(
+            status=CRSInferenceStatus.OUT_OF_JURISDICTION,
+            declared_epsg=declared_epsg,
+            reason=(
+                f"declared EPSG:{declared_epsg} is not in the jurisdiction "
+                f"allowlist {sorted(allowed)}"
+            ),
+        )
+
+    # 2. No declared CRS, no coordinates -> nothing to infer from.
+    if bounds_min is None or bounds_max is None:
+        candidates = [
+            CRSCandidate(z.epsg, z.name, 0.0) for z in jurisdiction if z.epsg in allowed
+        ]
+        return CRSInferenceResult(
+            status=CRSInferenceStatus.MISSING,
+            candidates=candidates,
+            reason="no declared CRS and no coordinate bounds available to infer from",
+        )
+
+    # 3. Infer from coordinate magnitude against the configured zone envelopes.
+    cx, cy = _centroid(bounds_min, bounds_max)
+    matches = [z for z in jurisdiction if z.contains(cx, cy) and z.epsg in allowed]
+
+    if len(matches) == 1:
+        zone = matches[0]
+        return CRSInferenceResult(
+            status=CRSInferenceStatus.INFERRED,
+            candidates=[
+                CRSCandidate(zone.epsg, zone.name, _fit_confidence(zone, bounds_min, bounds_max))
+            ],
+            reason=f"coordinate bounds fall inside a single jurisdiction zone (EPSG:{zone.epsg})",
+        )
+
+    if len(matches) > 1:
+        candidates = sorted(
+            (
+                CRSCandidate(z.epsg, z.name, _fit_confidence(z, bounds_min, bounds_max))
+                for z in matches
+            ),
+            key=lambda c: c.confidence,
+            reverse=True,
+        )
+        return CRSInferenceResult(
+            status=CRSInferenceStatus.AMBIGUOUS,
+            candidates=candidates,
+            reason=(
+                f"coordinate bounds match {len(matches)} jurisdiction zones "
+                f"{[c.epsg for c in candidates]}; operator must disambiguate"
+            ),
+        )
+
+    return CRSInferenceResult(
+        status=CRSInferenceStatus.OUT_OF_JURISDICTION,
+        reason="coordinate bounds fall outside every configured jurisdiction zone",
+    )

--- a/totali/geodetic/gatekeeper.py
+++ b/totali/geodetic/gatekeeper.py
@@ -20,6 +20,11 @@ from totali.pipeline.models import (
 from totali.pipeline.base_phase import PipelinePhase
 from totali.pipeline.context import PipelineContext
 from totali.audit.logger import AuditLogger
+from totali.geodetic.crs_inference import (
+    CRSInferenceStatus,
+    build_jurisdiction,
+    infer_crs,
+)
 
 
 class GeodeticGatekeeper(PipelinePhase):
@@ -40,6 +45,12 @@ class GeodeticGatekeeper(PipelinePhase):
         self.allowed_epsg = [c.to_epsg() for c in self.allowed_crs]
         self.reject_mixed_datum = config.get("reject_on_mixed_datum", True)
         self.reject_missing_crs = config.get("reject_on_missing_crs", True)
+        # U2: opt-in CRS inference. When enabled, a missing/undeclared CRS is
+        # inferred from coordinate bounds against the configured jurisdiction
+        # zones; ambiguity routes to quarantine, out-of-jurisdiction rejects.
+        # Defaults OFF so legacy ingestion behavior is unchanged.
+        self.crs_inference_enabled = config.get("crs_inference_enabled", False)
+        self.jurisdiction = build_jurisdiction(config)
         self.geoid_model = config.get("geoid_model", "GEOID18")
         # G-3: tolerance carried into unit_rejected audit payloads for
         # downstream elevation-precision checks.
@@ -65,15 +76,24 @@ class GeodeticGatekeeper(PipelinePhase):
         # Extract and validate CRS
         crs_meta = self._extract_crs(las, input_path)
 
+        # Compute stats early — CRS inference (U2) needs coordinate bounds, and
+        # stats don't depend on CRS validity.
+        stats = self._compute_stats(las, input_path, crs_meta)
+
+        # U2: no declared/resolvable CRS + inference enabled → infer or route.
+        if crs_meta.epsg_code == 0 and self.crs_inference_enabled:
+            routed = self._resolve_via_inference(
+                crs_meta, stats, input_path, output_dir
+            )
+            if routed is not None:
+                return routed
+
         if not crs_meta.is_valid:
             return PhaseResult(
                 phase="geodetic",
                 success=False,
                 message=f"CRS validation failed: {crs_meta.validation_errors}",
             )
-
-        # Compute stats
-        stats = self._compute_stats(las, input_path, crs_meta)
 
         # Hash input for chain of custody
         input_hash = self._hash_file(input_path)
@@ -136,6 +156,177 @@ class GeodeticGatekeeper(PipelinePhase):
             },
             output_files=[out_path, report_path],
         )
+
+    # ------------------------------------------------------------------
+    # U2: CRS inference + quarantine routing
+    # ------------------------------------------------------------------
+    def _resolve_via_inference(
+        self,
+        crs_meta: CRSMetadata,
+        stats: PointCloudStats,
+        input_path: Path,
+        output_dir: Path,
+    ) -> PhaseResult | None:
+        """Resolve an undeclared CRS. Returns a terminal PhaseResult to halt
+        (quarantine/reject), or ``None`` to proceed (CRS inferred or resolved).
+        """
+        item_id = input_path.stem
+        filename = input_path.name
+
+        # HITL loop closed: honor an operator resolution written back by the
+        # quarantine UI on a prior run rather than re-inferring.
+        resolution = self._read_operator_resolution(item_id, output_dir)
+        if resolution is not None and resolution.get("action") == "confirm":
+            epsg = resolution.get("epsg")
+            if epsg in self.allowed_epsg:
+                self._apply_inferred(
+                    crs_meta, epsg, source="operator_resolution",
+                    confidence=1.0, requires_review=False, candidates=[],
+                    reason="operator confirmed CRS via quarantine UI",
+                )
+                return None
+
+        result = infer_crs(
+            declared_epsg=None,
+            bounds_min=stats.bounds_min,
+            bounds_max=stats.bounds_max,
+            jurisdiction=self.jurisdiction,
+            allowed_epsg=self.allowed_epsg,
+        )
+
+        if result.status is CRSInferenceStatus.INFERRED:
+            cand = result.candidates[0]
+            self._apply_inferred(
+                crs_meta, cand.epsg, source="bounds_inference",
+                confidence=cand.confidence, requires_review=True,
+                candidates=result.candidates, reason=result.reason,
+            )
+            return None
+
+        if result.requires_quarantine:
+            self._route_to_quarantine(item_id, filename, stats, output_dir, result)
+            return PhaseResult(
+                phase="geodetic",
+                success=False,
+                message=f"CRS ambiguous; routed to quarantine: {result.reason}",
+                data={"quarantined": True, "item_id": item_id},
+            )
+
+        if result.is_rejected:
+            self.audit.log("crs_out_of_jurisdiction", {
+                "file": str(input_path),
+                "item_id": item_id,
+                "reason": result.reason,
+                "bounds_min": stats.bounds_min.tolist() if stats.bounds_min is not None else None,
+                "bounds_max": stats.bounds_max.tolist() if stats.bounds_max is not None else None,
+            })
+            return PhaseResult(
+                phase="geodetic",
+                success=False,
+                message=f"CRS out of jurisdiction; rejected: {result.reason}",
+                data={"rejected": True, "item_id": item_id},
+            )
+
+        # MISSING with no candidates → defer to the existing reject-missing path.
+        return None
+
+    def _apply_inferred(
+        self,
+        crs_meta: CRSMetadata,
+        epsg: int,
+        *,
+        source: str,
+        confidence: float,
+        requires_review: bool,
+        candidates: list,
+        reason: str = "",
+    ) -> None:
+        """Promote an inferred/resolved EPSG onto the CRS metadata and audit it.
+
+        The inferred CRS is advisory: `requires_review` rides along so downstream
+        consumers (and the surveyor) know it was not declared by the source data.
+        """
+        crs_meta.epsg_code = epsg
+        crs_meta.is_valid = True
+        crs_meta.validation_errors = []
+        crs_meta.source_datum = next(
+            (z.name for z in self.jurisdiction if z.epsg == epsg), crs_meta.source_datum
+        )
+        self.audit.log("crs_inferred", {
+            "epsg": epsg,
+            "source": source,
+            "confidence": confidence,
+            "requires_review": requires_review,
+            "candidates": [
+                {"epsg": c.epsg, "name": c.name, "confidence": c.confidence}
+                for c in candidates
+            ],
+            "reason": reason,
+        })
+
+    def _read_operator_resolution(self, item_id: str, output_dir: Path) -> dict | None:
+        path = Path(output_dir) / f"{item_id}_crs_resolution.json"
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def _route_to_quarantine(
+        self,
+        item_id: str,
+        filename: str,
+        stats: PointCloudStats,
+        output_dir: Path,
+        result,
+    ) -> None:
+        """Write the authoritative (flask-free) quarantine artifact, best-effort
+        enqueue into a live operator UI, and emit the audit event.
+        """
+        bmin = stats.bounds_min.tolist() if stats.bounds_min is not None else None
+        bmax = stats.bounds_max.tolist() if stats.bounds_max is not None else None
+        candidates = [
+            {"epsg": c.epsg, "name": c.name, "confidence": c.confidence}
+            for c in result.candidates
+        ]
+
+        artifact = Path(output_dir) / f"{item_id}_crs_quarantine.json"
+        artifact.write_text(json.dumps({
+            "item_id": item_id,
+            "filename": filename,
+            "point_count": stats.point_count,
+            "bounds_min": bmin,
+            "bounds_max": bmax,
+            "candidates": candidates,
+            "status": result.status.value,
+            "reason": result.reason,
+        }, indent=2))
+
+        # The JSON artifact above is authoritative and flask-free. The in-memory
+        # UI queue is a best-effort side channel — Flask is an optional dep.
+        try:
+            from totali.quarantine_ui.app import add_to_quarantine
+        except Exception:  # pragma: no cover - flask optional
+            add_to_quarantine = None
+        if add_to_quarantine is not None:
+            add_to_quarantine(
+                item_id=item_id,
+                filename=filename,
+                point_count=stats.point_count,
+                bounds_min=bmin,
+                bounds_max=bmax,
+                candidates=candidates,
+                output_dir=str(output_dir),
+            )
+
+        self.audit.log("crs_quarantined", {
+            "item_id": item_id,
+            "filename": filename,
+            "candidates": candidates,
+            "status": result.status.value,
+            "reason": result.reason,
+        })
 
     def _extract_crs(self, las: laspy.LasData, path: Path) -> CRSMetadata:
         meta = CRSMetadata(epsg_code=0)

--- a/totali/linting/certification.py
+++ b/totali/linting/certification.py
@@ -1,0 +1,157 @@
+"""U3 (scaffold): board/ALTA-aligned PLS certification record + gate.
+
+Assembles a certification record that references the full defensibility chain
+(raw hash -> classified -> extracted -> lint decisions -> certifier identity/seal
++ board/ALTA fields) and enforces DRAFT-until-certified. ``audit/verify.py``
+(:func:`verify_certification`) validates completeness and tamper-evidence.
+
+ADVISOR-DEPENDENT (OQ2 / KTD4 / scaffold): the concrete *set* of required board
+(design-partner state PLS) + ALTA fields is unknown and MUST be confirmed with
+the partner PLS advisor. :data:`REQUIRED_BOARD_ALTA_FIELDS` is intentionally an
+empty TODO — do NOT invent field names or values here. The mechanism below
+(record structure, chain linkage, the open-item gate, completeness + tamper
+verification) is complete and is tested against a caller-supplied required set;
+only the production field list awaits the advisor.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional, Sequence
+
+from totali.pipeline.models import GeometryStatus, LintItem
+
+# TODO(advisor / OQ2): replace with the design partner's state board PLS rule
+# fields + the applicable ALTA/NSPS table-A items, confirmed by the PLS advisor.
+# Shipping an empty tuple on purpose — inventing field names would undermine the
+# certification's defensibility (the whole moat). `verify_certification` accepts
+# a caller-supplied required set so the contract is exercisable before the
+# advisor lands.
+REQUIRED_BOARD_ALTA_FIELDS: tuple[str, ...] = ()
+
+# Lint statuses that still need a surveyor decision before certification.
+_OPEN_STATUSES = frozenset({GeometryStatus.DRAFT, GeometryStatus.FLAGGED})
+
+
+class CertificationBlocked(Exception):
+    """Raised when open lint items remain and no deferral reason was given."""
+
+
+@dataclass
+class CertifierIdentity:
+    name: str
+    license_number: str
+    jurisdiction: str
+    seal_ref: Optional[str] = None
+
+    def is_complete(self) -> bool:
+        return bool(self.name and self.license_number and self.jurisdiction)
+
+
+@dataclass
+class CertificationRecord:
+    project_id: str
+    certifier: CertifierIdentity
+    raw_hash: str
+    classified_ref: str
+    extracted_ref: str
+    lint_decision_refs: list[str]
+    board_alta_fields: dict[str, Any] = field(default_factory=dict)
+    defer_reason: Optional[str] = None
+    status: str = GeometryStatus.CERTIFIED.value
+    timestamp: str = ""
+
+    def chain_refs(self) -> list[str]:
+        """Ordered references along the defensibility chain."""
+        return [self.raw_hash, self.classified_ref, self.extracted_ref, *self.lint_decision_refs]
+
+    def record_hash(self) -> str:
+        """SHA-256 over the canonical record content (tamper-evidence)."""
+        payload = {
+            "project_id": self.project_id,
+            "certifier": asdict(self.certifier),
+            "raw_hash": self.raw_hash,
+            "classified_ref": self.classified_ref,
+            "extracted_ref": self.extracted_ref,
+            "lint_decision_refs": self.lint_decision_refs,
+            "board_alta_fields": self.board_alta_fields,
+            "defer_reason": self.defer_reason,
+            "status": self.status,
+        }
+        blob = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+        return hashlib.sha256(blob).hexdigest()
+
+    def to_dict(self) -> dict:
+        out = asdict(self)
+        out["record_hash"] = self.record_hash()
+        return out
+
+
+def export_blocked(lint_items: Sequence[LintItem]) -> bool:
+    """DRAFT-until-certified: True while any item still needs a decision.
+
+    Mirrors the promote gate in ``surveyor_lint.py`` — DRAFT/FLAGGED output must
+    not be exported as a deliverable until the surveyor resolves (or explicitly
+    defers) it.
+    """
+    return any(i.status in _OPEN_STATUSES for i in lint_items)
+
+
+def certify(
+    *,
+    project_id: str,
+    certifier: CertifierIdentity,
+    raw_hash: str,
+    classified_ref: str,
+    extracted_ref: str,
+    lint_items: Sequence[LintItem],
+    board_alta_fields: dict[str, Any],
+    defer_reason: Optional[str] = None,
+    audit: Any = None,
+    timestamp: Optional[str] = None,
+) -> CertificationRecord:
+    """Build a certification record after enforcing the open-item gate.
+
+    Raises :class:`CertificationBlocked` if any lint item is still open
+    (DRAFT/FLAGGED) and no ``defer_reason`` is supplied. Completeness of the
+    board/ALTA field set is NOT enforced here (the required set is advisor-defined
+    and validated separately by :func:`verify_certification`).
+    """
+    open_items = [i for i in lint_items if i.status in _OPEN_STATUSES]
+    if open_items and not defer_reason:
+        raise CertificationBlocked(
+            f"{len(open_items)} lint item(s) still open "
+            f"({[i.item_id for i in open_items]}); resolve them or pass an "
+            "explicit defer_reason. Certification cannot proceed over silent DRAFTs."
+        )
+
+    record = CertificationRecord(
+        project_id=project_id,
+        certifier=certifier,
+        raw_hash=raw_hash,
+        classified_ref=classified_ref,
+        extracted_ref=extracted_ref,
+        lint_decision_refs=[f"{i.item_id}:{i.status.value}" for i in lint_items],
+        board_alta_fields=dict(board_alta_fields),
+        defer_reason=defer_reason,
+        status=GeometryStatus.CERTIFIED.value,
+        timestamp=timestamp or datetime.now(timezone.utc).isoformat(),
+    )
+
+    if audit is not None:
+        audit.log("certify", {
+            "project_id": project_id,
+            "pls_name": certifier.name,
+            "pls_license": certifier.license_number,
+            "jurisdiction": certifier.jurisdiction,
+            "raw_hash": raw_hash,
+            "chain_refs": record.chain_refs(),
+            "board_alta_field_keys": sorted(record.board_alta_fields),
+            "record_hash": record.record_hash(),
+            "defer_reason": defer_reason,
+        })
+
+    return record

--- a/totali/main.py
+++ b/totali/main.py
@@ -28,8 +28,12 @@ from totali.audit.logger import AuditLogger
 @click.option("--output", "output_dir", default="output",
               help="Output directory")
 @click.option("--project-id", default=None, help="Project identifier for audit trail")
+@click.option("--manual-baseline-sec", type=float, default=None,
+              help="U5: wall-clock seconds for the equivalent manual drafting effort, "
+                   "captured into the timing metrics for the pilot baseline (SC2). "
+                   "No time-savings percentage is computed.")
 @click.option("--dry-run", is_flag=True, help="Validate config and inputs without processing")
-def main(input_path, config_path, phase, output_dir, project_id, dry_run):
+def main(input_path, config_path, phase, output_dir, project_id, manual_baseline_sec, dry_run):
     """TOTaLi-Assisted Drafting Pipeline"""
 
     # Load config
@@ -68,7 +72,7 @@ def main(input_path, config_path, phase, output_dir, project_id, dry_run):
     pipeline = PipelineOrchestrator(config.model_dump(), audit, output_path)
 
     try:
-        result = pipeline.run(input_path, phase=phase)
+        result = pipeline.run(input_path, phase=phase, manual_baseline_sec=manual_baseline_sec)
         audit.log("pipeline_complete", {
             "status": "success",
             "outputs": [str(p) for p in result.output_files],

--- a/totali/pipeline/metrics.py
+++ b/totali/pipeline/metrics.py
@@ -1,0 +1,81 @@
+"""U5: pipeline timing instrumentation — the pilot's measured baseline (R7/SC2).
+
+Aggregates per-phase and total wall-clock timing from a :class:`PipelineResult`
+into a metrics artifact written *alongside the audit record*, optionally carrying
+an operator-supplied manual baseline for later comparison.
+
+IMPORTANT (KTD5 / SC2): this module records **raw seconds only**. It deliberately
+does NOT compute or emit any time-savings percentage. The manual baseline is
+measured during the pilot and the public claim is set post-measurement — there
+is no committed number to fabricate here.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class PhaseTiming:
+    phase: str
+    duration_sec: float
+    success: bool
+
+
+@dataclass
+class RunMetrics:
+    project_id: str
+    total_duration_sec: float
+    phases: list[PhaseTiming] = field(default_factory=list)
+    # Operator-supplied wall-clock for the equivalent manual drafting effort.
+    # Absent by default — never fabricated.
+    manual_baseline_sec: Optional[float] = None
+
+    @classmethod
+    def from_pipeline_result(
+        cls, result, manual_baseline_sec: Optional[float] = None
+    ) -> "RunMetrics":
+        return cls(
+            project_id=result.project_id,
+            total_duration_sec=result.duration_sec,
+            phases=[
+                PhaseTiming(p.phase, p.duration_sec, p.success) for p in result.phases
+            ],
+            manual_baseline_sec=manual_baseline_sec,
+        )
+
+    def to_dict(self) -> dict:
+        out: dict = {
+            "project_id": self.project_id,
+            "total_duration_sec": self.total_duration_sec,
+            "phases": [
+                {"phase": p.phase, "duration_sec": p.duration_sec, "success": p.success}
+                for p in self.phases
+            ],
+        }
+        # Optional and absent by default. No derived percentage — see KTD5/SC2.
+        if self.manual_baseline_sec is not None:
+            out["manual_baseline_sec"] = self.manual_baseline_sec
+        return out
+
+    def write(self, audit, output_dir: Optional[Path] = None) -> Path:
+        """Write the metrics artifact next to the audit record and emit a
+        `metrics_recorded` audit event. Returns the artifact path.
+
+        The artifact lives beside the audit log (``<audit-log>.metrics.json``) so
+        the timing record travels with the chain-of-custody it describes.
+        """
+        log_path = Path(audit.log_path)
+        artifact = log_path.with_suffix(".metrics.json")
+        artifact.write_text(json.dumps(self.to_dict(), indent=2))
+
+        audit.log("metrics_recorded", {
+            "artifact": str(artifact),
+            "total_duration_sec": self.total_duration_sec,
+            "phase_count": len(self.phases),
+            "manual_baseline_sec": self.manual_baseline_sec,
+        })
+        return artifact

--- a/totali/pipeline/orchestrator.py
+++ b/totali/pipeline/orchestrator.py
@@ -42,7 +42,12 @@ class PipelineOrchestrator:
             "lint": SurveyorLinter(self.config.linting, audit),
         }
 
-    def run(self, input_path: str, phase: str = "all") -> PipelineResult:
+    def run(
+        self,
+        input_path: str,
+        phase: str = "all",
+        manual_baseline_sec: Optional[float] = None,
+    ) -> PipelineResult:
         t0 = time.time()
         result = PipelineResult(
             project_id=self.config.project.name
@@ -143,6 +148,15 @@ class PipelineOrchestrator:
         result.extraction = context.extraction
         result.healing = context.healing
         result.duration_sec = time.time() - t0
+
+        # U5: instrument timing. Emit a metrics artifact alongside the audit
+        # record so the pilot baseline (SC2) is measurable. Raw seconds only —
+        # no committed time-savings percentage (KTD5).
+        from totali.pipeline.metrics import RunMetrics
+        RunMetrics.from_pipeline_result(
+            result, manual_baseline_sec=manual_baseline_sec
+        ).write(self.audit)
+
         return result
 
     def _phase_timeout(self, phase_name: str) -> Optional[float]:

--- a/totali/segmentation/classifier.py
+++ b/totali/segmentation/classifier.py
@@ -3,9 +3,20 @@ Phase 2: Discriminative ML Segmentation
 ========================================
 Non-authoritative classification. Produces probabilities + confidence, NOT geometry.
 Uses ONNX runtime for model inference on point cloud batches.
-"""
 
-from pathlib import Path
+U1 (HITL classifier): the model is loaded through the deterministic
+``totali.models.loader.load_onnx`` sha256/manifest contract — a hash/manifest
+mismatch fails loudly instead of silently classifying with a tampered model.
+Surveyor corrections of these *advisory* labels are captured by
+``totali.segmentation.corrections.CorrectionStore`` (the training flywheel).
+
+TODO(KTD3 / partner-data): the model *choice* — adapt a pretrained point-cloud
+model vs. train a custom one — is the first execution-time research spike and
+requires the design-partner dataset in hand. Until that lands there is no
+provisioned ONNX model, so the rule-based fallback below is the live path. Do
+NOT fabricate a model or training data here; wire HITL against the loader
+contract only.
+"""
 
 import numpy as np
 
@@ -33,6 +44,9 @@ class PointCloudClassifier(PipelinePhase):
         self.batch_size = config.get("batch_size", 65536)
         self.voxel_size = config.get("voxel_size", 0.05)
         self.classes = config.get("classes", {})
+        # U1: optional integrity inputs threaded into the sha256/manifest loader.
+        self.expected_sha256 = config.get("expected_sha256")
+        self.manifest = config.get("manifest")
         self.session = None
 
     def validate_inputs(self, context: PipelineContext) -> tuple[bool, list[str]]:
@@ -44,23 +58,43 @@ class PointCloudClassifier(PipelinePhase):
         return len(errors) == 0, errors
 
     def _load_model(self):
-        """Load ONNX model. Falls back to rule-based if model not found."""
-        model_file = Path(self.model_path)
-        if not model_file.exists():
+        """Load the ONNX model via the deterministic sha256/manifest loader.
+
+        Returns True with ``self.session`` set on success. Benign absence — no
+        model file on disk, or onnxruntime not installed — returns False and logs
+        a warning so the caller uses the rule-based fallback.
+
+        A hash or manifest MISMATCH is deliberately NOT caught: it means the
+        on-disk model is not the one we provisioned (tamper/corruption), so it
+        propagates loudly rather than letting us silently classify with the
+        wrong model.
+        """
+        from totali.models.loader import (
+            ManifestError,
+            ModelHashMismatch,
+            ModelNotFoundError,
+            load_onnx,
+        )
+
+        try:
+            self.session = load_onnx(
+                self.model_path,
+                device=self.device,
+                expected_sha256=self.expected_sha256,
+                manifest=self.manifest,
+            )
+            return True
+        except ModelNotFoundError:
             self.audit.log("classify", {
                 "warning": f"Model not found at {self.model_path}, using rule-based fallback"
             })
             return False
-
-        try:
-            import onnxruntime as ort
-            providers = ["CUDAExecutionProvider", "CPUExecutionProvider"] \
-                if self.device == "cuda" else ["CPUExecutionProvider"]
-            self.session = ort.InferenceSession(str(model_file), providers=providers)
-            return True
         except ImportError:
             self.audit.log("classify", {"warning": "onnxruntime not available, using fallback"})
             return False
+        # ModelHashMismatch / ManifestError intentionally propagate (loud failure).
+        except (ModelHashMismatch, ManifestError):
+            raise
 
     def run(self, context: PipelineContext) -> PhaseResult:
         points_xyz = context.points_xyz

--- a/totali/segmentation/corrections.py
+++ b/totali/segmentation/corrections.py
@@ -1,0 +1,129 @@
+"""U1: surveyor correction capture — the HITL training-data flywheel.
+
+The classifier (``totali/segmentation/classifier.py``) produces *advisory,
+non-authoritative* labels. When a surveyor corrects one during review, that
+correction is captured here as a labeled delta keyed to the audit record ID,
+accumulating training data for the next model iteration.
+
+Hard invariants:
+
+- **Never mutates authoritative geometry or classifier output.** This is a
+  one-way sink: corrections live in their own JSONL store, separate from the
+  DRAFT/certified geometry pipeline.
+- **Linked to the audit chain.** Every record carries the ``audit_id`` of the
+  run it corrects, so the flywheel is traceable to a specific, hashed pipeline
+  execution.
+
+NOTE (KTD3 / scaffold): how this accumulated data is *consumed* — adapt a
+pretrained point-cloud model vs. train a custom one — is the data-dependent
+research spike that requires the partner dataset. That decision is deliberately
+left as a TODO in ``classifier.py``; the capture contract below is complete.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Sequence
+
+_STORE_FILENAME = "corrections.jsonl"
+
+
+@dataclass(frozen=True)
+class Correction:
+    """One surveyor correction of an advisory classifier label."""
+
+    audit_id: str
+    point_index: int
+    original_label: int
+    corrected_label: int
+    surveyor: str
+    timestamp: str
+    notes: str = ""
+
+
+class CorrectionStore:
+    """Append-only JSONL store of surveyor corrections under ``store_dir``."""
+
+    def __init__(self, store_dir: str | Path):
+        self.store_dir = Path(store_dir)
+        self.store_dir.mkdir(parents=True, exist_ok=True)
+        self.path = self.store_dir / _STORE_FILENAME
+
+    def record(
+        self,
+        audit_id: str,
+        point_index: int,
+        original_label: int,
+        corrected_label: int,
+        surveyor: str,
+        notes: str = "",
+        timestamp: Optional[str] = None,
+    ) -> Correction:
+        """Append one labeled correction. Returns the persisted record.
+
+        Does not touch any geometry or classifier output — only this store.
+        """
+        correction = Correction(
+            audit_id=audit_id,
+            point_index=int(point_index),
+            original_label=int(original_label),
+            corrected_label=int(corrected_label),
+            surveyor=surveyor,
+            timestamp=timestamp or datetime.now(timezone.utc).isoformat(),
+            notes=notes,
+        )
+        with self.path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(asdict(correction)) + "\n")
+        return correction
+
+    def record_batch(
+        self,
+        audit_id: str,
+        point_indices: Sequence[int],
+        original_labels: Sequence[int],
+        corrected_labels: Sequence[int],
+        surveyor: str,
+        notes: str = "",
+    ) -> list[Correction]:
+        """Record many corrections from the same review session."""
+        out: list[Correction] = []
+        for idx, orig, corr in zip(point_indices, original_labels, corrected_labels):
+            out.append(self.record(audit_id, idx, orig, corr, surveyor, notes))
+        return out
+
+    def all_corrections(self) -> list[Correction]:
+        """Read back every accumulated correction (the training flywheel)."""
+        if not self.path.exists():
+            return []
+        out: list[Correction] = []
+        with self.path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    out.append(Correction(**json.loads(line)))
+        return out
+
+    def corrections_for(self, audit_id: str) -> list[Correction]:
+        """All corrections linked to a specific audit/run id."""
+        return [c for c in self.all_corrections() if c.audit_id == audit_id]
+
+    def export_training_data(self) -> list[dict]:
+        """Project corrections into a minimal labeled-sample shape for training.
+
+        ``corrected_label`` becomes the supervised ``label``; ``original_label``
+        is retained for error analysis. The concrete training pipeline is the
+        deferred KTD3 spike (needs the partner dataset).
+        """
+        return [
+            {
+                "audit_id": c.audit_id,
+                "point_index": c.point_index,
+                "label": c.corrected_label,
+                "original_label": c.original_label,
+                "surveyor": c.surveyor,
+            }
+            for c in self.all_corrections()
+        ]


### PR DESCRIPTION
## Summary

Implements the **commercial v1 vertical** from the plan: topo LiDAR → defensible DXF for the design-partner PLS firm. Spine reused; this is gap-fill + hardening.

Plan: `CAD/docs/plans/2026-06-17-001-feat-totali-defensible-dxf-v1-plan.md`
Requirements: `CAD/docs/brainstorms/2026-06-17-cad-survey-pipeline-commercial-requirements.md`
(both in the `~/Dev` superproject)

## Units

**Fully implemented**
- **U2** CRS inference + quarantine routing (`geodetic/crs_inference.py`, `gatekeeper.py`, +364 test lines)
- **U5** timing instrumentation for the pilot baseline (`pipeline/metrics.py`; raw seconds only, no committed % per KTD5)
- **U6** CI on every push/PR with green mocked gates

**Scaffold (await external input — deliberately not fabricated)**
- **U1** HITL loader contract + correction capture (`segmentation/corrections.py`); model choice is the KTD3 spike, needs partner dataset
- **U3** board/ALTA certification record + verify (`linting/certification.py`); `REQUIRED_BOARD_ALTA_FIELDS` is an explicit empty TODO pending the PLS advisor (OQ2)
- **U4** DXF audit reference + real-LAS E2E contract; the real-partner-LAS E2E is skipped until data arrives, DWG remains a loud stub

## Verification
- `ruff` clean
- `pytest` **860 passed / 3 skipped** (baseline 808/2 → +52 tests)

## Notes
- DWG deferred (LibreDWG-GPL vs ODA/Teigha decision out of v1 scope).
- Scaffolds intentionally contain no invented partner/board data.

Made with [Cursor](https://cursor.com)