### PR TITLE
feat(pipeline): wire coded survey exports through PHASE_ORDER

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -125,8 +125,10 @@ audit:
     - "unit_rejected"
     # Phase 2 (segmentation)
     - "classify"
+    - "classify_coded"   # coded .asc/.crd survey exports (authoritative)
     # Phase 3 (extraction)
     - "extract"
+    - "extract_coded"    # coded survey → DXF point placement
     # Phase 4 (cad_shielding)
     - "heal"
     - "insert"

--- a/tests/test_coded_survey_pipeline.py
+++ b/tests/test_coded_survey_pipeline.py
@@ -1,0 +1,100 @@
+"""Integration tests for coded-survey (.asc) → DXF pipeline wiring."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from totali.fieldcodes import load_field_codes
+from totali.pipeline.input_kind import input_kind, is_coded_survey_input
+from totali.pipeline.orchestrator import PipelineOrchestrator
+
+SAMPLE_FLD = """#2010V# Code|Description|Symbol|Symbol Size|Layer
+FIELD CODE|Layer|Symbol|0.0000|none
+TOPO|TOPO|DOT1|0.0000|none
+CP|CONTROL_POINT|CTRLPT|0.0000|none
+"""
+
+SAMPLE_ASC = (
+    "1,1372340.54,2818546.82,8010.78,TOPO shot grade\n"
+    "2,1372341.10,2818547.00,8010.90,CP control\n"
+    "3,1372342.00,2818548.00,8011.00,TOPO second shot\n"
+)
+
+
+@pytest.fixture
+def coded_survey_config(tmp_path, sample_config):
+    fld = tmp_path / "codes.fld"
+    fld.write_text(SAMPLE_FLD, encoding="utf-8")
+    cfg = dict(sample_config)
+    cfg["geodetic"] = dict(sample_config["geodetic"])
+    cfg["geodetic"]["fieldcode_fld"] = str(fld)
+    cfg["geodetic"]["crs_inference_enabled"] = False
+    cfg["segmentation"] = dict(sample_config["segmentation"])
+    cfg["segmentation"]["fieldcode_fld"] = str(fld)
+    return cfg
+
+
+@pytest.fixture
+def coded_asc(tmp_path):
+    p = tmp_path / "job.asc"
+    p.write_text(SAMPLE_ASC, encoding="utf-8")
+    return p
+
+
+class TestInputKind:
+    def test_detects_asc(self, coded_asc):
+        assert is_coded_survey_input(coded_asc)
+        assert input_kind(coded_asc) == "coded_survey"
+
+    def test_detects_las(self, tmp_path):
+        las = tmp_path / "cloud.las"
+        las.write_bytes(b"\x00")
+        assert input_kind(las) == "las"
+
+
+class TestCodedSurveyPipeline:
+    def test_geodetic_through_shield(
+        self, audit_logger, coded_survey_config, coded_asc, tmp_path
+    ):
+        out = tmp_path / "out"
+        out.mkdir()
+        orch = PipelineOrchestrator(coded_survey_config, audit_logger, out)
+        result = orch.run(str(coded_asc), phase="all")
+
+        phase_names = [p.phase for p in result.phases]
+        assert phase_names[:4] == ["geodetic", "segment", "extract", "shield"]
+        assert result.phases[0].success is True
+        assert result.phases[1].success is True
+        assert result.phases[2].success is True
+        assert result.phases[3].success is True
+
+        dxf = out / "totali_draft_output.dxf"
+        assert dxf.exists()
+
+        manifest_path = out / "entity_manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["entity_count"] == 3
+        layers = {e["layer"] for e in manifest["entities"]}
+        assert "TOTaLi-SURV-TOPO-DRAFT" in layers
+        assert "TOTaLi-SURV-CTRL-DRAFT" in layers
+        assert manifest.get("audit_reference", {}).get("input_hash")
+
+    def test_segment_uses_coded_classifier_not_las_classifier(
+        self, audit_logger, coded_survey_config, coded_asc, tmp_path
+    ):
+        out = tmp_path / "out"
+        out.mkdir()
+        orch = PipelineOrchestrator(coded_survey_config, audit_logger, out)
+        result = orch.run(str(coded_asc), phase="segment")
+
+        # segment alone does not run geodetic — expect validation failure
+        assert result.phases[-1].phase == "segment"
+        assert result.phases[-1].success is False
+
+    def test_field_code_table_fixture(self, tmp_path):
+        fld = tmp_path / "codes.fld"
+        fld.write_text(SAMPLE_FLD, encoding="utf-8")
+        table = load_field_codes(fld)
+        assert table.layer_for("TOPO") == "TOPO"

--- a/totali/cad_shielding/shield.py
+++ b/totali/cad_shielding/shield.py
@@ -270,6 +270,30 @@ class CADShield(PipelinePhase):
         for layer_name in self.layer_map.values():
             doc.layers.add(layer_name)
 
+        # Coded survey shots (authoritative points on conforming DRAFT layers)
+        for pt in extraction.coded_survey_points:
+            entity_id = self._entity_id()
+            try:
+                if pt.draft_layer not in doc.layers:
+                    doc.layers.add(pt.draft_layer)
+                msp.add_point(
+                    (pt.x, pt.y, pt.z),
+                    dxfattribs={"layer": pt.draft_layer},
+                )
+                entities.append(self._entity_record(
+                    entity_id, "POINT", pt.draft_layer,
+                    np.array([pt.x, pt.y, pt.z]),
+                    confidence=1.0,
+                    provenance={
+                        "point_id": pt.point_id,
+                        "field_code": pt.field_code,
+                        "firm_layer": pt.firm_layer,
+                        "authoritative": True,
+                    },
+                ))
+            except Exception:
+                pass
+
         # DTM as 3DFACE entities
         if extraction.dtm_vertices is not None and extraction.dtm_faces is not None:
             layer = self.layer_map.get("ground_surface", "TOTaLi-SURV-DTM-DRAFT")

--- a/totali/extraction/extractor.py
+++ b/totali/extraction/extractor.py
@@ -30,6 +30,10 @@ class DeterministicExtractor(PipelinePhase):
 
     def validate_inputs(self, context: PipelineContext) -> tuple[bool, list[str]]:
         errors: list[str] = []
+        if context.input_kind == "coded_survey":
+            if not context.coded_survey_points:
+                errors.append("coded_survey_points missing; run segment phase first")
+            return len(errors) == 0, errors
         if context.points_xyz is None:
             errors.append("points_xyz missing; run geodetic phase first")
         if context.classification is None:
@@ -37,6 +41,8 @@ class DeterministicExtractor(PipelinePhase):
         return len(errors) == 0, errors
 
     def run(self, context: PipelineContext) -> PhaseResult:
+        if context.input_kind == "coded_survey":
+            return self._run_coded(context)
         xyz = context.points_xyz
         classification: ClassificationResult | None = context.classification
         output_dir = Path(context.output_dir)
@@ -147,6 +153,35 @@ class DeterministicExtractor(PipelinePhase):
                 "input_hash": context.input_hash,
             },
             output_files=[report_path],
+        )
+
+    def _run_coded(self, context: PipelineContext) -> PhaseResult:
+        survey_pts = context.coded_survey_points or []
+        if not survey_pts:
+            return PhaseResult(
+                phase="extract",
+                success=False,
+                message="No coded survey points to extract",
+            )
+
+        result = ExtractionResult(coded_survey_points=list(survey_pts))
+        self.audit.log("extract_coded", {
+            "point_count": len(survey_pts),
+            "draft_layers": sorted({p.draft_layer for p in survey_pts}),
+        })
+
+        return PhaseResult(
+            phase="extract",
+            success=True,
+            message=f"Prepared {len(survey_pts)} coded survey points for DXF",
+            data={
+                "extraction": result,
+                "points_xyz": context.points_xyz,
+                "crs": context.crs,
+                "stats": context.stats,
+                "input_hash": context.input_hash,
+                "input_kind": "coded_survey",
+            },
         )
 
     def _build_dtm(self, ground_pts: np.ndarray) -> tuple:

--- a/totali/geodetic/gatekeeper.py
+++ b/totali/geodetic/gatekeeper.py
@@ -7,6 +7,7 @@ Rejects ambiguous inputs. Applies PROJ-based transformations.
 
 import hashlib
 import json
+import os
 from pathlib import Path
 
 import numpy as np
@@ -14,6 +15,9 @@ import laspy
 from pyproj import CRS, Transformer
 from pyproj.exceptions import CRSError
 
+from totali.fieldcodes import DESCRIPTIONS_PATH_ENV, FLD_PATH_ENV, load_field_codes
+from totali.pipeline.input_kind import is_coded_survey_input
+from totali.segmentation.dataset import parse_asc
 from totali.pipeline.models import (
     PhaseResult, CRSMetadata, PointCloudStats
 )
@@ -68,6 +72,11 @@ class GeodeticGatekeeper(PipelinePhase):
 
     def run(self, context: PipelineContext) -> PhaseResult:
         input_path = Path(context.input_path)
+        if is_coded_survey_input(input_path):
+            return self._run_coded_survey(context, input_path)
+        return self._run_las(context, input_path)
+
+    def _run_las(self, context: PipelineContext, input_path: Path) -> PhaseResult:
         output_dir = Path(context.output_dir)
 
         # Read point cloud
@@ -155,6 +164,130 @@ class GeodeticGatekeeper(PipelinePhase):
                 "input_hash": input_hash,
             },
             output_files=[out_path, report_path],
+        )
+
+    def _run_coded_survey(self, context: PipelineContext, input_path: Path) -> PhaseResult:
+        """Ingest a Carlson ``.asc``/``.crd`` export (N,E,Z + field code).
+
+        Coded exports carry no LAS CRS metadata; the project ``allowed_crs`` is
+        treated as the declared CRS. Bounds are still validated against the
+        jurisdiction allowlist when CRS inference is enabled.
+        """
+        output_dir = Path(context.output_dir)
+        fld_path = self.config.get("fieldcode_fld") or os.environ.get(FLD_PATH_ENV)
+        if not fld_path:
+            return PhaseResult(
+                phase="geodetic",
+                success=False,
+                message=(
+                    f"coded survey input requires geodetic.fieldcode_fld or {FLD_PATH_ENV}"
+                ),
+            )
+
+        desc_path = self.config.get("fieldcode_descriptions") or os.environ.get(
+            DESCRIPTIONS_PATH_ENV
+        )
+        table = load_field_codes(fld_path, desc_path)
+        labeled = parse_asc(input_path, table)
+        if not labeled:
+            return PhaseResult(
+                phase="geodetic",
+                success=False,
+                message="No survey points parsed from coded export",
+            )
+
+        if not self.allowed_epsg or self.allowed_epsg[0] is None:
+            return PhaseResult(
+                phase="geodetic",
+                success=False,
+                message="allowed_crs must declare the project CRS for coded survey input",
+            )
+
+        epsg = self.allowed_epsg[0]
+        crs_meta = CRSMetadata(
+            epsg_code=epsg,
+            is_valid=True,
+            geoid_model=self.geoid_model,
+            horizontal_unit=self.config.get("elevation_unit", "US_survey_foot"),
+            vertical_unit=self.config.get("elevation_unit", "US_survey_foot"),
+            epoch=self.config.get("required_epoch"),
+            source_datum=next(
+                (z.name for z in self.jurisdiction if z.epsg == epsg), None
+            ),
+        )
+
+        # State Plane convention: X=easting, Y=northing, Z=elevation.
+        points_xyz = np.array(
+            [[p.easting, p.northing, p.elevation] for p in labeled],
+            dtype=np.float64,
+        )
+        stats = PointCloudStats(
+            point_count=len(labeled),
+            bounds_min=points_xyz.min(axis=0),
+            bounds_max=points_xyz.max(axis=0),
+            has_rgb=False,
+            has_intensity=False,
+            has_classification=False,
+            source_file=str(input_path),
+            crs=crs_meta,
+        )
+
+        if self.crs_inference_enabled:
+            routed = self._resolve_via_inference(
+                crs_meta, stats, input_path, output_dir
+            )
+            if routed is not None:
+                return routed
+
+        input_hash = self._hash_file(input_path)
+        self.audit.log("ingest", {
+            "file": str(input_path),
+            "sha256": input_hash,
+            "point_count": stats.point_count,
+            "input_kind": "coded_survey",
+            "crs": f"EPSG:{crs_meta.epsg_code}",
+            "bounds_min": stats.bounds_min.tolist(),
+            "bounds_max": stats.bounds_max.tolist(),
+        })
+
+        report_path = output_dir / f"{input_path.stem}_geodetic_report.json"
+        report = {
+            "input_file": str(input_path),
+            "input_hash": input_hash,
+            "input_kind": "coded_survey",
+            "crs": {
+                "epsg": crs_meta.epsg_code,
+                "epoch": crs_meta.epoch,
+                "geoid": crs_meta.geoid_model,
+                "h_unit": crs_meta.horizontal_unit,
+                "v_unit": crs_meta.vertical_unit,
+                "source": "project_allowed_crs",
+            },
+            "point_count": stats.point_count,
+            "bounds": {
+                "min": stats.bounds_min.tolist(),
+                "max": stats.bounds_max.tolist(),
+            },
+            "transform_applied": False,
+            "validation_passed": True,
+        }
+        with open(report_path, "w") as f:
+            json.dump(report, f, indent=2)
+
+        return PhaseResult(
+            phase="geodetic",
+            success=True,
+            message="Coded survey ingested with project CRS",
+            data={
+                "points_xyz": points_xyz,
+                "las": None,
+                "crs": crs_meta,
+                "stats": stats,
+                "input_hash": input_hash,
+                "input_kind": "coded_survey",
+                "coded_points": labeled,
+            },
+            output_files=[report_path],
         )
 
     # ------------------------------------------------------------------

--- a/totali/pipeline/context.py
+++ b/totali/pipeline/context.py
@@ -50,8 +50,10 @@ class PipelineContext(BaseModel):
 
     input_path: str
     output_dir: Path
+    input_kind: str | None = None
 
     points_xyz: np.ndarray | None = None
+    coded_survey_points: list | None = None
     las: Any = None
     crs: CRSMetadata | None = None
     stats: PointCloudStats | None = None

--- a/totali/pipeline/input_kind.py
+++ b/totali/pipeline/input_kind.py
@@ -1,0 +1,30 @@
+"""Detect pipeline input kind from file extension."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_CODED_SURVEY_SUFFIXES = frozenset({".asc", ".crd", ".txt"})
+_LAS_SUFFIXES = frozenset({".las", ".laz"})
+
+
+def is_coded_survey_input(path: str | Path) -> bool:
+    return Path(path).suffix.lower() in _CODED_SURVEY_SUFFIXES
+
+
+def is_las_input(path: str | Path) -> bool:
+    return Path(path).suffix.lower() in _LAS_SUFFIXES
+
+
+def input_kind(path: str | Path) -> str:
+    """Return ``las`` or ``coded_survey``; raises ValueError for unknown types."""
+    p = Path(path)
+    suffix = p.suffix.lower()
+    if suffix in _LAS_SUFFIXES:
+        return "las"
+    if suffix in _CODED_SURVEY_SUFFIXES:
+        return "coded_survey"
+    raise ValueError(
+        f"unsupported input extension {suffix!r} on {p.name!r}; "
+        f"expected one of {sorted(_LAS_SUFFIXES | _CODED_SURVEY_SUFFIXES)}"
+    )

--- a/totali/pipeline/models.py
+++ b/totali/pipeline/models.py
@@ -78,9 +78,23 @@ class ClassificationResult:
             )
 
 
+@dataclass(frozen=True)
+class CodedSurveyPoint:
+    """One authoritative survey shot for coded-export → DXF placement."""
+
+    point_id: str
+    x: float
+    y: float
+    z: float
+    draft_layer: str
+    field_code: str
+    firm_layer: Optional[str] = None
+
+
 @dataclass
 class ExtractionResult:
     """Deterministic geometry extraction outputs."""
+    coded_survey_points: list = field(default_factory=list)
     dtm_vertices: Optional[np.ndarray] = None
     dtm_faces: Optional[np.ndarray] = None
     breaklines: list = field(default_factory=list)       # list of Nx3 arrays

--- a/totali/pipeline/orchestrator.py
+++ b/totali/pipeline/orchestrator.py
@@ -13,6 +13,7 @@ from typing import Optional
 from totali.pipeline.models import PipelineResult, PhaseResult
 from totali.pipeline.context import PipelineConfig, PipelineContext
 from totali.audit.logger import AuditLogger
+from totali.pipeline.input_kind import is_coded_survey_input
 
 
 PHASE_ORDER = ["geodetic", "segment", "extract", "shield", "lint"]
@@ -31,6 +32,7 @@ class PipelineOrchestrator:
         # Initialize phase processors
         from totali.geodetic.gatekeeper import GeodeticGatekeeper
         from totali.segmentation.classifier import PointCloudClassifier
+        from totali.segmentation.coded_classifier_phase import CodedPointClassifier
         from totali.extraction.extractor import DeterministicExtractor
         from totali.cad_shielding.shield import CADShield
         from totali.linting.surveyor_lint import SurveyorLinter
@@ -41,6 +43,7 @@ class PipelineOrchestrator:
             "shield": CADShield(self.config.cad_shielding, audit),
             "lint": SurveyorLinter(self.config.linting, audit),
         }
+        self._coded_segment = CodedPointClassifier(self.config.segmentation, audit)
 
     def run(
         self,
@@ -60,7 +63,7 @@ class PipelineOrchestrator:
         )
 
         for phase_name in phases_to_run:
-            processor = self.phases[phase_name]
+            processor = self._processor_for_phase(phase_name, context)
             self.audit.log("phase_start", {"phase": phase_name})
 
             pt0 = time.time()
@@ -158,6 +161,11 @@ class PipelineOrchestrator:
         ).write(self.audit)
 
         return result
+
+    def _processor_for_phase(self, phase_name: str, context: PipelineContext):
+        if phase_name == "segment" and is_coded_survey_input(context.input_path):
+            return self._coded_segment
+        return self.phases[phase_name]
 
     def _phase_timeout(self, phase_name: str) -> Optional[float]:
         """P-6: resolve per-phase timeout. Order:

--- a/totali/segmentation/coded_classifier_phase.py
+++ b/totali/segmentation/coded_classifier_phase.py
@@ -1,0 +1,95 @@
+"""Phase 2 (coded survey): deterministic field-code classification."""
+
+from __future__ import annotations
+
+import os
+
+from totali.audit.logger import AuditLogger
+from totali.fieldcodes import DESCRIPTIONS_PATH_ENV, FLD_PATH_ENV, load_field_codes
+from totali.pipeline.base_phase import PipelinePhase
+from totali.pipeline.context import PipelineContext
+from totali.pipeline.models import CodedSurveyPoint, PhaseResult
+from totali.segmentation.coded import classify_coded_points, draft_layer_counts
+from totali.segmentation.dataset import LabeledPoint, parse_asc
+
+
+class CodedPointClassifier(PipelinePhase):
+    """Classify coded survey exports via the field-code taxonomy (authoritative)."""
+
+    phase_name = "segment"
+
+    def __init__(self, config: dict, audit: AuditLogger):
+        super().__init__(config, audit)
+        self.discipline = config.get("discipline", "SURV")
+
+    def validate_inputs(self, context: PipelineContext) -> tuple[bool, list[str]]:
+        errors: list[str] = []
+        if context.input_kind != "coded_survey":
+            errors.append("input_kind must be coded_survey")
+        coded = context.extras.get("coded_points")
+        if not coded and context.points_xyz is None:
+            errors.append("coded_points missing; run geodetic phase first")
+        return len(errors) == 0, errors
+
+    def _load_points(self, context: PipelineContext) -> list[LabeledPoint]:
+        cached = context.extras.get("coded_points")
+        if cached:
+            return cached
+        table = self._field_code_table()
+        return parse_asc(context.input_path, table)
+
+    def _field_code_table(self):
+        fld = self.config.get("fieldcode_fld") or os.environ.get(FLD_PATH_ENV)
+        if not fld:
+            raise RuntimeError(
+                f"set segmentation.fieldcode_fld or {FLD_PATH_ENV} for coded survey input"
+            )
+        desc = self.config.get("fieldcode_descriptions") or os.environ.get(
+            DESCRIPTIONS_PATH_ENV
+        )
+        return load_field_codes(fld, desc)
+
+    def run(self, context: PipelineContext) -> PhaseResult:
+        points = self._load_points(context)
+        if not points:
+            return PhaseResult(
+                phase="segment",
+                success=False,
+                message="No coded survey points parsed from input",
+            )
+
+        classifications = classify_coded_points(points, discipline=self.discipline)
+        layer_counts = draft_layer_counts(classifications)
+
+        survey_points = [
+            CodedSurveyPoint(
+                point_id=c.point_id,
+                x=p.easting,
+                y=p.northing,
+                z=p.elevation,
+                draft_layer=c.draft_layer,
+                field_code=c.field_code,
+                firm_layer=c.firm_layer,
+            )
+            for p, c in zip(points, classifications)
+        ]
+
+        self.audit.log("classify_coded", {
+            "point_count": len(points),
+            "labeled_count": sum(1 for p in points if p.is_labeled),
+            "draft_layer_counts": layer_counts,
+            "authoritative": True,
+        })
+
+        return PhaseResult(
+            phase="segment",
+            success=True,
+            message=(
+                f"Classified {len(points)} coded points "
+                f"({sum(1 for p in points if p.is_labeled)} labeled)"
+            ),
+            data={
+                "coded_survey_points": survey_points,
+                "input_kind": "coded_survey",
+            },
+        )


### PR DESCRIPTION
## Summary

- Adds a **coded-survey input path** for Carlson `.asc`/`.crd` exports alongside the existing LAS LiDAR path
- **Geodetic** ingests N,E,Z + field codes; CRS comes from project `allowed_crs`
- **Segment** dispatches to `CodedPointClassifier` (authoritative taxonomy → DRAFT layers), not the advisory ONNX classifier
- **Extract** passes `CodedSurveyPoint` list; **Shield** writes DXF `POINT` entities on conforming `TOTaLi-*-DRAFT` layers
- Audit allowlist: `classify_coded`, `extract_coded`

## Config

Set `geodetic.fieldcode_fld` and `segmentation.fieldcode_fld`, or `TOTALI_FIELDCODE_FLD`.

## Test plan

- [x] `pytest` — 935 passed / 2 skipped
- [x] `ruff check` on changed modules
- [ ] Run on a real partner `.asc` export with `TOTALI_FIELDCODE_FLD` pointed at firm `.fld`


Made with [Cursor](https://cursor.com)