### PR TITLE
docs(agents): add Dev-root boundary section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # AGENTS.md
 
+## Dev-root boundary
+
+This file is project-local. `~/Dev` is only the workspace container; once a session is inside this repo, use this file plus `CLAUDE.md` and project docs as the active rules.
+
+- Scope searches, build commands, tests, terrain-pipeline checks, and dataset validation to this repository unless a sibling repo is explicitly named.
+- Load project-specific code intelligence, schema checks, GIS/database tooling, dataset tooling, and CI checks from this repo's docs only.
+- If work touches another folder inside `~/Dev`, switch to that folder's own `AGENTS.md` before editing there.
+- Do not refresh or rely on a `~/Dev`-wide index as the source of truth for this project.
+
 ## Cursor Cloud specific instructions
 
 This is a pure-Python monorepo with four sub-projects. No Docker, Node.js, or external services are required for development.


### PR DESCRIPTION
## Summary
- Recovers the only relevant change from stash `wip: local dirty tree pre-pr`
- Adds a **Dev-root boundary** section to `AGENTS.md` so agents scope work to this repo and route cross-folder edits via sibling `AGENTS.md` files

## Stash triage (same session)
| Stash content | Verdict | Action |
|---------------|---------|--------|
| `AGENTS.md` (+9 lines) | **Relevant** | This PR |
| 149× `AUTOMATICCAD/files/` deletions (~961k lines) | **Irrelevant now** | Dropped; files still on disk; separate `chore/automaticcad-corpus-prune` if intentional |
| `.DS_Store` / `__pycache__` | **Irrelevant** | Dropped |
| Duplicate stash entry | **Duplicate** | Dropped |

Related geodetic work is already in #109.

## Test plan
- [x] Docs-only change — no code impact
- [ ] CI (should be no-op / fast pass)


Made with [Cursor](https://cursor.com)