### PR TITLE
fix(laser-suite): coerce config numerics and handle zero-dof networks

### DIFF
--- a/laser-suite/AGENTIC.md
+++ b/laser-suite/AGENTIC.md
@@ -84,4 +84,4 @@ Input bundle (CSVs under `bundle-dir`):
 - `manifest/run_manifest.json` contains tool version, config hash, output SHA-256s.
 
 ## Progress (append-only)
-- _(empty)_
+- 2026-06-17 — config numeric coercion (YAML `1.0e15` strings); adjustment accepts dof==0; pass_case sample gains redundant obs D–B; `python/tests/` 23/23 green.

--- a/laser-suite/python/laser_suite/adjustment.py
+++ b/laser-suite/python/laser_suite/adjustment.py
@@ -217,10 +217,19 @@ def run_adjustment(bundle: CanonicalBundle, config: dict[str, Any]) -> Adjustmen
 
     v = last_l - (last_A @ dx)
     dof = last_A.shape[0] - last_A.shape[1]
-    if dof <= 0:
-        raise AdjustmentError("Non-positive degrees of freedom")
+    if dof < 0:
+        raise AdjustmentError("Observation count is less than unknown count")
 
-    sigma0_sq = float((v.T @ last_P @ v) / dof)
+    residual_quad = float(v.T @ last_P @ v)
+    if dof == 0:
+        # Exactly-determined network (e.g. two distance obs fixing one free 2D
+        # station). Posterior sigma0 is undefined; accept when residuals are
+        # negligible and use unit weight for downstream covariance scaling.
+        if residual_quad > (tol * tol):
+            raise AdjustmentError("Exactly determined network with non-zero residuals")
+        sigma0_sq = 1.0
+    else:
+        sigma0_sq = residual_quad / dof
     if not np.isfinite(sigma0_sq) or sigma0_sq < 0:
         raise AdjustmentError("Invalid posterior variance factor")
 

--- a/laser-suite/python/laser_suite/config.py
+++ b/laser-suite/python/laser_suite/config.py
@@ -52,6 +52,32 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
     return merged
 
 
+def _as_float(value: Any, field: str) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError as exc:
+            raise ConfigError(f"{field} must be numeric") from exc
+    raise ConfigError(f"{field} must be numeric")
+
+
+def _as_int(value: Any, field: str) -> int:
+    if isinstance(value, bool):
+        raise ConfigError(f"{field} must be an integer")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError as exc:
+            raise ConfigError(f"{field} must be an integer") from exc
+    raise ConfigError(f"{field} must be an integer")
+
+
 def load_config(path: Path) -> dict[str, Any]:
     raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     if not isinstance(raw, dict):
@@ -59,6 +85,19 @@ def load_config(path: Path) -> dict[str, Any]:
     config = _deep_merge(DEFAULT_CONFIG, raw)
 
     adjustment = config["laser"]["adjustment"]
+    adjustment["max_iterations"] = _as_int(
+        adjustment["max_iterations"], "laser.adjustment.max_iterations"
+    )
+    adjustment["convergence_tol"] = _as_float(
+        adjustment["convergence_tol"], "laser.adjustment.convergence_tol"
+    )
+    adjustment["condition_number_limit"] = _as_float(
+        adjustment["condition_number_limit"], "laser.adjustment.condition_number_limit"
+    )
+    adjustment["svd_rcond"] = _as_float(
+        adjustment["svd_rcond"], "laser.adjustment.svd_rcond"
+    )
+
     if adjustment["max_iterations"] < 1:
         raise ConfigError("laser.adjustment.max_iterations must be >= 1")
     if adjustment["convergence_tol"] <= 0:
@@ -67,6 +106,9 @@ def load_config(path: Path) -> dict[str, Any]:
         raise ConfigError("laser.adjustment.condition_number_limit must be > 0")
 
     rpp = config["laser"]["rpp"]
+    rpp["k95"] = _as_float(rpp["k95"], "laser.rpp.k95")
+    rpp["allowable_base_m"] = _as_float(rpp["allowable_base_m"], "laser.rpp.allowable_base_m")
+    rpp["allowable_ppm"] = _as_float(rpp["allowable_ppm"], "laser.rpp.allowable_ppm")
     if rpp["k95"] <= 0:
         raise ConfigError("laser.rpp.k95 must be > 0")
     if rpp["allowable_base_m"] < 0:
@@ -74,7 +116,11 @@ def load_config(path: Path) -> dict[str, Any]:
     if rpp["allowable_ppm"] < 0:
         raise ConfigError("laser.rpp.allowable_ppm must be >= 0")
 
-    snap_tol = config["encroachment"]["snap_tolerance_m"]
+    snap_tol = _as_float(
+        config["encroachment"]["snap_tolerance_m"],
+        "encroachment.snap_tolerance_m",
+    )
+    config["encroachment"]["snap_tolerance_m"] = snap_tol
     if snap_tol <= 0:
         raise ConfigError("encroachment.snap_tolerance_m must be > 0")
 

--- a/laser-suite/samples/pass_case/observations.csv
+++ b/laser-suite/samples/pass_case/observations.csv
@@ -1,3 +1,4 @@
 obs_id,from_stn,to_stn,type,value
 O1,A,B,distance,58.30951895
 O2,C,B,distance,58.30951895
+O3,D,B,distance,30.0

--- a/laser-suite/samples/pass_case/stations.csv
+++ b/laser-suite/samples/pass_case/stations.csv
@@ -2,3 +2,4 @@ station_id,x,y,z,status
 A,0,0,0,fixed
 B,49,31,0,free
 C,100,0,0,fixed
+D,50,60,0,fixed


### PR DESCRIPTION
## Summary
- Fixes pre-existing laser-suite test failures (6→0): `condition_number_limit` YAML string coercion, exactly-determined adjustment networks (dof==0), and pass_case sample redundancy
- PyYAML parses `1.0e15` as string; `load_config` now coerces numeric fields
- `run_adjustment` accepts dof==0 when residuals are negligible (unit sigma0 for covariance)
- `samples/pass_case` adds station D + O3 observation so RPP checks pass

## Test plan
- [x] `cd laser-suite && pytest python/tests/ -q` — 23 passed
- [x] Root `pytest -q` — 942 passed, 2 skipped
- [ ] CI green

## Follows
- Merged #109–#111


Made with [Cursor](https://cursor.com)