### PR TITLE
feat(geodetic): GEOID allowlist + PROJ audit metadata (G-7/G-8)

### DIFF
--- a/AGENTIC_ORCHESTRATION.md
+++ b/AGENTIC_ORCHESTRATION.md
@@ -92,7 +92,7 @@ If the task conflicts with a TOTaLi invariant, output exactly: INVARIANT CONFLIC
     { "name": "repl",          "status": "planned",     "language": "Python", "path": "totali/repl/",          "deps": ["audit","cad_shielding","linting"] },
     { "name": "dwg_tool_parser","status": "stub",       "language": "Python+C++", "path": "dwg-tool-parser/",  "deps": ["cad_shielding"] }
   ],
-  "current_task_id": "G-7",
+  "current_task_id": "G-9",
   "completed_tasks": [],
   "constraints": [
     "No undocumented libraries",
@@ -254,7 +254,7 @@ CURRENT MODULE CONTEXT
   ],
   "current_generation": {
     "current_module": "geodetic",
-    "current_plan_step": "G-7",
+    "current_plan_step": "G-9",
     "validation_rules": [
       "must_lint_clean", "must_pass_unit_tests", "must_pass_integration",
       "must_emit_audit_events_for_new_actions",

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -16,6 +16,8 @@ geodetic:
     - "EPSG:6430"   # NAD83(2011) Colorado Central (ftUS)
   required_epoch: "2010.0"
   geoid_model: "GEOID18"
+  allowed_geoid_models:
+    - "GEOID18"
   unit_tolerance_ft: 0.01
   reject_on_mixed_datum: true
   reject_on_missing_crs: true
@@ -127,6 +129,8 @@ audit:
     - "crs_out_of_jurisdiction"  # U2: bounds outside every configured zone
     - "unit_validated"
     - "unit_rejected"
+    - "geoid_validated"
+    - "geoid_rejected"
     # Phase 2 (segmentation)
     - "classify"
     - "classify_coded"   # coded .asc/.crd survey exports (authoritative)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,8 @@ class _FakeLaspyModule:
 _ensure_stub("pyproj", {
     "CRS": _FakeCRS,
     "Transformer": _FakeTransformer,
+    "__version__": "3.7.2",
+    "proj_version_str": "9.5.1",
 })
 _ensure_stub("pyproj.exceptions", {"CRSError": type("CRSError", (Exception,), {})})
 

--- a/tests/test_geodetic_geoid.py
+++ b/tests/test_geodetic_geoid.py
@@ -1,0 +1,117 @@
+"""G-7/G-8 coverage: GEOID allowlist enforcement and PROJ audit metadata."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from totali.geodetic.gatekeeper import GeodeticGatekeeper
+
+
+@pytest.fixture
+def base_config():
+    return {
+        "allowed_crs": ["EPSG:2231"],
+        "reject_on_missing_crs": True,
+        "geoid_model": "GEOID18",
+        "allowed_geoid_models": ["GEOID18"],
+        "elevation_unit": "US_survey_foot",
+        "unit_tolerance_ft": 0.01,
+    }
+
+
+@pytest.fixture
+def gatekeeper_with_audit(audit_logger, base_config):
+    gk = GeodeticGatekeeper(base_config, audit_logger)
+    return gk, audit_logger
+
+
+def _assert_proj_keys(payload: dict, gk: GeodeticGatekeeper) -> None:
+    ctx = gk._proj_runtime_context()
+    assert payload["pyproj_version"] == ctx["pyproj_version"]
+    assert payload["proj_version"] == ctx["proj_version"]
+
+
+class TestGeoidAllowlist:
+    def test_geoid18_validated_without_sidecar(self, gatekeeper_with_audit):
+        gk, audit = gatekeeper_with_audit
+        errors, resolved = gk._validate_geoid(Path("sample.las"), None)
+        assert errors == []
+        assert resolved == "GEOID18"
+        events = audit.get_events("geoid_validated")
+        assert len(events) == 1
+        payload = events[0]["data"]
+        assert payload["resolved_geoid"] == "GEOID18"
+        assert payload["declared_geoid"] is None
+        assert payload["allowlist"] == ["GEOID18"]
+        _assert_proj_keys(payload, gk)
+
+    def test_declared_geoid18_accepted(self, gatekeeper_with_audit, tmp_path):
+        gk, audit = gatekeeper_with_audit
+        las_path = tmp_path / "site.las"
+        las_path.write_bytes(b"\x00")
+        sidecar = tmp_path / "site_geodetic_meta.json"
+        sidecar.write_text(json.dumps({"geoid_model": "geoid18"}))
+
+        errors, resolved = gk._validate_geoid(las_path, gk._read_declared_geoid(las_path))
+        assert errors == []
+        assert resolved == "GEOID18"
+        assert audit.get_events("geoid_validated")
+
+    def test_unsupported_geoid_rejected(self, gatekeeper_with_audit, tmp_path):
+        gk, audit = gatekeeper_with_audit
+        las_path = tmp_path / "bad.las"
+        las_path.write_bytes(b"\x00")
+
+        errors, resolved = gk._validate_geoid(las_path, "GEOID12")
+        assert errors
+        assert resolved is None
+        assert "GEOID12" in errors[0]
+        rejected = audit.get_events("geoid_rejected")
+        assert len(rejected) == 1
+        payload = rejected[0]["data"]
+        assert payload["declared_geoid"] == "GEOID12"
+        assert payload["reason"] == "geoid_not_allowed"
+        assert payload["allowlist"] == ["GEOID18"]
+        _assert_proj_keys(payload, gk)
+        assert not audit.get_events("geoid_validated")
+
+    def test_reject_helper_payload_shape(self, gatekeeper_with_audit):
+        gk, audit = gatekeeper_with_audit
+        gk._reject_unsupported_geoid(Path("x.las"), "GEOID09", "GEOID18")
+        payload = audit.get_events("geoid_rejected")[0]["data"]
+        assert set(payload.keys()) >= {
+            "file",
+            "declared_geoid",
+            "expected_geoid",
+            "allowlist",
+            "reason",
+            "pyproj_version",
+            "proj_version",
+        }
+
+
+class TestProjAuditContextOnOtherEvents:
+    def test_unit_validated_includes_proj_versions(self, gatekeeper_with_audit):
+        gk, audit = gatekeeper_with_audit
+        from totali.pipeline.models import CRSMetadata
+
+        meta = CRSMetadata(
+            epsg_code=2231,
+            horizontal_unit="US_survey_foot",
+            vertical_unit="US_survey_foot",
+        )
+        errors = gk._validate_units(meta, Path("good.las"))
+        assert errors == []
+        _assert_proj_keys(audit.get_events("unit_validated")[0]["data"], gk)
+
+    def test_extract_crs_emits_geoid_validated(self, gatekeeper_with_audit):
+        gk, audit = gatekeeper_with_audit
+        import laspy
+
+        las = laspy.read("fake")
+        las.vlrs = []
+        meta = gk._extract_crs(las, Path("no_crs.las"))
+        assert meta.is_valid is False
+        assert audit.get_events("geoid_validated")
+        _assert_proj_keys(audit.get_events("geoid_validated")[0]["data"], gk)

--- a/totali/geodetic/AGENTIC.md
+++ b/totali/geodetic/AGENTIC.md
@@ -58,6 +58,7 @@ cases to the quarantine UI on port 5050 for operator decision.
 Existing:
 - `tests/test_geodetic.py`
 - `tests/test_crs_inference.py`
+- `tests/test_geodetic_geoid.py`
 
 Missing / to add:
 - `tests/test_geodetic_deterministic.py` — double-run byte reproducibility.
@@ -71,7 +72,6 @@ Missing / to add:
 ## Open questions / known debts
 - Epoch tolerance: allow `2010.0 ± δ` or exact match only? Default currently exact.
   Decide and test before Phase 2 ships to production.
-- No test yet verifying `pyproj` / PROJ versions are captured in audit payload.
 
 ## Definition of Done
 - All G-1..G-9 plan items implemented with tests.
@@ -81,3 +81,4 @@ Missing / to add:
 
 ## Progress (append-only)
 - 2026-06-17 — G-5/G-6: `crs_confidence_threshold` + `auto_assign_high_confidence` wired in gatekeeper; sub-threshold INFERRED routes to quarantine UI (:5050); `tests/test_geodetic_quarantine_trigger.py` 5 passed.
+- 2026-06-17 — G-7/G-8: `allowed_geoid_models` allowlist + optional `{stem}_geodetic_meta.json` declared geoid; `geoid_validated` / `geoid_rejected` audit events; all geodetic audit payloads carry `pyproj_version` + `proj_version`; `tests/test_geodetic_geoid.py`.

--- a/totali/geodetic/gatekeeper.py
+++ b/totali/geodetic/gatekeeper.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import numpy as np
 import laspy
+import pyproj
 from pyproj import CRS, Transformer
 from pyproj.exceptions import CRSError
 
@@ -62,6 +63,12 @@ class GeodeticGatekeeper(PipelinePhase):
         self.auto_assign_high_confidence = config.get("auto_assign_high_confidence", True)
         self.quarantine_ui_port = int(config.get("quarantine_ui_port", 5050))
         self.geoid_model = config.get("geoid_model", "GEOID18")
+        allowed_geoids = config.get("allowed_geoid_models")
+        if allowed_geoids is None:
+            allowed_geoids = [self.geoid_model]
+        self.allowed_geoid_models = frozenset(
+            self._normalize_geoid(name) for name in allowed_geoids
+        )
         # G-3: tolerance carried into unit_rejected audit payloads for
         # downstream elevation-precision checks.
         self.unit_tolerance_ft = float(config.get("unit_tolerance_ft", 0.01))
@@ -112,24 +119,24 @@ class GeodeticGatekeeper(PipelinePhase):
 
         # Hash input for chain of custody
         input_hash = self._hash_file(input_path)
-        self.audit.log("ingest", {
+        self.audit.log("ingest", self._audit_payload({
             "file": str(input_path),
             "sha256": input_hash,
             "point_count": stats.point_count,
             "crs": f"EPSG:{crs_meta.epsg_code}",
             "bounds_min": stats.bounds_min.tolist() if stats.bounds_min is not None else None,
             "bounds_max": stats.bounds_max.tolist() if stats.bounds_max is not None else None,
-        })
+        }))
 
         # Transform if needed
         points_xyz, transform_applied = self._apply_transforms(las, crs_meta)
 
         if transform_applied:
-            self.audit.log("transform", {
+            self.audit.log("transform", self._audit_payload({
                 "from_crs": f"EPSG:{crs_meta.epsg_code}",
                 "to_crs": f"EPSG:{self.allowed_epsg[0]}",
                 "geoid": self.geoid_model,
-            })
+            }))
 
         # Write standardized output
         out_path = output_dir / f"{input_path.stem}_gated.las"
@@ -245,8 +252,18 @@ class GeodeticGatekeeper(PipelinePhase):
             if routed is not None:
                 return routed
 
+        declared_geoid = self._read_declared_geoid(input_path)
+        geoid_errors, resolved_geoid = self._validate_geoid(input_path, declared_geoid)
+        if geoid_errors:
+            return PhaseResult(
+                phase="geodetic",
+                success=False,
+                message=f"Geoid validation failed: {geoid_errors}",
+            )
+        crs_meta.geoid_model = resolved_geoid
+
         input_hash = self._hash_file(input_path)
-        self.audit.log("ingest", {
+        self.audit.log("ingest", self._audit_payload({
             "file": str(input_path),
             "sha256": input_hash,
             "point_count": stats.point_count,
@@ -254,7 +271,7 @@ class GeodeticGatekeeper(PipelinePhase):
             "crs": f"EPSG:{crs_meta.epsg_code}",
             "bounds_min": stats.bounds_min.tolist(),
             "bounds_max": stats.bounds_max.tolist(),
-        })
+        }))
 
         report_path = output_dir / f"{input_path.stem}_geodetic_report.json"
         report = {
@@ -374,13 +391,13 @@ class GeodeticGatekeeper(PipelinePhase):
             )
 
         if result.is_rejected:
-            self.audit.log("crs_out_of_jurisdiction", {
+            self.audit.log("crs_out_of_jurisdiction", self._audit_payload({
                 "file": str(input_path),
                 "item_id": item_id,
                 "reason": result.reason,
                 "bounds_min": stats.bounds_min.tolist() if stats.bounds_min is not None else None,
                 "bounds_max": stats.bounds_max.tolist() if stats.bounds_max is not None else None,
-            })
+            }))
             return PhaseResult(
                 phase="geodetic",
                 success=False,
@@ -413,7 +430,7 @@ class GeodeticGatekeeper(PipelinePhase):
         crs_meta.source_datum = next(
             (z.name for z in self.jurisdiction if z.epsg == epsg), crs_meta.source_datum
         )
-        self.audit.log("crs_inferred", {
+        self.audit.log("crs_inferred", self._audit_payload({
             "epsg": epsg,
             "source": source,
             "confidence": confidence,
@@ -423,7 +440,7 @@ class GeodeticGatekeeper(PipelinePhase):
                 for c in candidates
             ],
             "reason": reason,
-        })
+        }))
 
     def _read_operator_resolution(self, item_id: str, output_dir: Path) -> dict | None:
         path = Path(output_dir) / f"{item_id}_crs_resolution.json"
@@ -481,13 +498,13 @@ class GeodeticGatekeeper(PipelinePhase):
                 output_dir=str(output_dir),
             )
 
-        self.audit.log("crs_quarantined", {
+        self.audit.log("crs_quarantined", self._audit_payload({
             "item_id": item_id,
             "filename": filename,
             "candidates": candidates,
             "status": result.status.value,
             "reason": result.reason,
-        })
+        }))
 
     def _extract_crs(self, las: laspy.LasData, path: Path) -> CRSMetadata:
         meta = CRSMetadata(epsg_code=0)
@@ -521,10 +538,16 @@ class GeodeticGatekeeper(PipelinePhase):
                 f"EPSG:{meta.epsg_code} not in allowed CRS list: {self.allowed_epsg}"
             )
 
-        meta.geoid_model = self.geoid_model
+        meta.epoch = self.config.get("required_epoch")
+
+        declared_geoid = self._read_declared_geoid(path)
+        geoid_errors, resolved_geoid = self._validate_geoid(path, declared_geoid)
+        errors.extend(geoid_errors)
+        if resolved_geoid is not None:
+            meta.geoid_model = resolved_geoid
+
         meta.horizontal_unit = self.config.get("elevation_unit", "US_survey_foot")
         meta.vertical_unit = self.config.get("elevation_unit", "US_survey_foot")
-        meta.epoch = self.config.get("required_epoch")
 
         # G-3: unit validation after defaults. Categorical — no silent coercion.
         errors.extend(self._validate_units(meta, path))
@@ -569,7 +592,7 @@ class GeodeticGatekeeper(PipelinePhase):
         def _emit_mismatch(axis: str, declared: str) -> None:
             self.audit.log(
                 "unit_rejected",
-                {
+                self._audit_payload({
                     "file": str(path),
                     "axis": axis,
                     "declared_unit": declared,
@@ -578,7 +601,7 @@ class GeodeticGatekeeper(PipelinePhase):
                     "expected_unit": canonical,
                     "tolerance_ft": self.unit_tolerance_ft,
                     "reason": "unit_mismatch",
-                },
+                }),
             )
 
         if h_unit and h_unit not in allowed_aliases:
@@ -597,13 +620,13 @@ class GeodeticGatekeeper(PipelinePhase):
         if not errors:
             self.audit.log(
                 "unit_validated",
-                {
+                self._audit_payload({
                     "file": str(path),
                     "horizontal_unit": h_unit,
                     "vertical_unit": v_unit,
                     "canonical_unit": canonical,
                     "tolerance_ft": self.unit_tolerance_ft,
-                },
+                }),
             )
 
         return errors
@@ -612,14 +635,96 @@ class GeodeticGatekeeper(PipelinePhase):
         """G-3: canonical metric-rejection audit event."""
         self.audit.log(
             "unit_rejected",
-            {
+            self._audit_payload({
                 "file": str(path),
                 "horizontal_unit": h_unit,
                 "vertical_unit": v_unit,
                 "expected_unit": canonical,
                 "tolerance_ft": self.unit_tolerance_ft,
                 "reason": "metric_not_allowed",
-            },
+            }),
+        )
+
+    @staticmethod
+    def _normalize_geoid(name: str | None) -> str:
+        return (name or "").strip().upper().replace(" ", "").replace("-", "")
+
+    def _proj_runtime_context(self) -> dict[str, str]:
+        """G-8: reproducibility metadata for every geodetic audit payload."""
+        version = getattr(pyproj, "__version__", "unknown")
+        proj_version = getattr(pyproj, "proj_version_str", None)
+        if proj_version is None:
+            proj_version = getattr(pyproj, "PROJ_VERSION_STR", "unknown")
+        return {
+            "pyproj_version": str(version),
+            "proj_version": str(proj_version),
+        }
+
+    def _audit_payload(self, data: dict) -> dict:
+        return {**data, **self._proj_runtime_context()}
+
+    def _read_declared_geoid(self, path: Path) -> str | None:
+        """Optional sidecar ``{stem}_geodetic_meta.json`` with ``geoid_model`` key."""
+        meta_path = path.parent / f"{path.stem}_geodetic_meta.json"
+        if not meta_path.exists():
+            return None
+        try:
+            payload = json.loads(meta_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+        declared = payload.get("geoid_model")
+        return str(declared) if declared else None
+
+    def _validate_geoid(
+        self, path: Path, declared: str | None
+    ) -> tuple[list[str], str | None]:
+        """G-7: enforce configured GEOID allowlist; never substitute models."""
+        errors: list[str] = []
+        canonical = self.geoid_model
+        canonical_norm = self._normalize_geoid(canonical)
+
+        if canonical_norm not in self.allowed_geoid_models:
+            errors.append(
+                f"Configured geoid_model {canonical!r} is not on the allowlist: "
+                f"{sorted(self.allowed_geoid_models)}"
+            )
+            return errors, None
+
+        if declared:
+            declared_norm = self._normalize_geoid(declared)
+            if declared_norm not in self.allowed_geoid_models:
+                self._reject_unsupported_geoid(path, declared, canonical)
+                errors.append(
+                    f"Declared geoid {declared!r} is not allowed; "
+                    f"allowlist={sorted(self.allowed_geoid_models)}. "
+                    "No silent substitution."
+                )
+                return errors, None
+
+        self.audit.log(
+            "geoid_validated",
+            self._audit_payload({
+                "file": str(path),
+                "declared_geoid": declared,
+                "resolved_geoid": canonical,
+                "allowlist": sorted(self.allowed_geoid_models),
+            }),
+        )
+        return errors, canonical
+
+    def _reject_unsupported_geoid(
+        self, path: Path, declared: str, canonical: str
+    ) -> None:
+        """G-7: canonical unsupported-geoid audit event."""
+        self.audit.log(
+            "geoid_rejected",
+            self._audit_payload({
+                "file": str(path),
+                "declared_geoid": declared,
+                "expected_geoid": canonical,
+                "allowlist": sorted(self.allowed_geoid_models),
+                "reason": "geoid_not_allowed",
+            }),
         )
 
     def _compute_stats(


### PR DESCRIPTION
## Summary
- **G-7:** Add `allowed_geoid_models` allowlist; validate optional `{stem}_geodetic_meta.json` declared geoid; emit `geoid_validated` / `geoid_rejected` (no silent substitution).
- **G-8:** Merge `pyproj_version` and `proj_version` into every geodetic audit payload via `_audit_payload()`.
- New `tests/test_geodetic_geoid.py` (6 tests); Block 6 advances to **G-9**.

## Test plan
- [x] `pytest tests/test_geodetic_geoid.py` — 6 passed
- [x] `pytest -q` — 948 passed, 2 skipped
- [x] `tests/test_audit_events_exhaustive.py` — new events allowlisted
- [ ] CI green on merge


Made with [Cursor](https://cursor.com)